### PR TITLE
[Fix] #20 - 토큰 만료로 인한 리프래쉬 토큰으로 토큰 갱신 처리 에러 해결

### DIFF
--- a/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
@@ -4,44 +4,29 @@
 //
 //  Created by 정정욱 on 1/22/25.
 //
-
 import Foundation
 import Moya
 
 final class TokenRefreshPlugin: PluginType {
-    private let keychainManager = TokenKeychainManager.shared
-    private let tokenRefreshProvider = MoyaProvider<TokenRefreshType>(plugins: [MoyaPlugin.shared])
+    private let keychain = TokenKeychainManager.shared
+    private let provider = MoyaProvider<TokenRefreshType>(plugins: [MoyaPlugin.shared])
     private var isRefreshing = false
     private var refreshQueue: [(Bool) -> Void] = []
 
-    func process(_ result: Result<Response, MoyaError>, target: TargetType) -> Result<Response, MoyaError> {
-        print("TokenRefreshPlugin - process called")  // 디버깅용 로그
-        
-        switch result {
-        case .failure(let error):
-            if let response = error.response, response.statusCode == 401 {
-                print("TokenRefreshPlugin - 401 error detected")  // 디버깅용 로그
-                
-                handleTokenRefresh { [weak self] success in
-                    guard let self = self else { return }
-                    
-                    if success {
-                        print("Token successfully refreshed. Retrying request...")
-                        self.retryMoyaRequest(target: target)
-                    } else {
-                        print("Token refresh failed.")
-                    }
-                }
-            }
-        case .success(let response):
-            print("TokenRefreshPlugin - Success response: \(response.statusCode)")  // 디버깅용 로그
+    // MARK: - 감지된 401 처리
+    func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
+        guard case let .success(response) = result, response.statusCode == 401 else { return }
+
+        print("🔐 [TokenRefreshPlugin] 401 detected. Starting refresh...")
+
+        handleTokenRefresh { success in
+            print(success ? "✅ Token refreshed." : "❌ Token refresh failed.")
+            // 재시도는 외부에서 해야 함
         }
-        
-        return result
     }
 
-
-    private func handleTokenRefresh(completion: @escaping (Bool) -> Void) {
+    // MARK: - 토큰 리프레시 처리
+    func handleTokenRefresh(completion: @escaping (Bool) -> Void) {
         guard !isRefreshing else {
             refreshQueue.append(completion)
             return
@@ -50,59 +35,46 @@ final class TokenRefreshPlugin: PluginType {
         isRefreshing = true
 
         do {
-            guard let refreshToken = try keychainManager.getRefreshToken() else {
-                print("[ERROR] No Refresh Token Available")
+            guard let refreshToken = try keychain.getRefreshToken() else {
+                print("[ERROR] No refresh token found.")
                 completeRefresh(success: false)
                 return
             }
 
-            tokenRefreshProvider.request(.auth(refreshToken: refreshToken)) { [weak self] result in
-                guard let self = self else { return }
+            provider.request(.auth(refreshToken: refreshToken)) { [weak self] result in
+                guard let self else { return }
 
                 switch result {
                 case .success(let response):
-                    if (200..<300).contains(response.statusCode) {
-                        do {
-                            let decodedResponse = try JSONDecoder().decode(NewAccessTokenResponse.self, from: response.data)
-                            try self.keychainManager.saveAccessToken(decodedResponse.accessToken)
-                            try self.keychainManager.saveRefreshToken(decodedResponse.refreshToken)
-                            print("[INFO] Access Token successfully refreshed.")
-                            self.completeRefresh(success: true)
-                        } catch {
-                            print("[ERROR] Failed to decode token refresh response: \(error.localizedDescription)")
-                            self.completeRefresh(success: false)
-                        }
-                    } else {
-                        print("[ERROR] Token refresh failed with status code: \(response.statusCode)")
-                        self.completeRefresh(success: false)
-                    }
-
+                    self.processRefreshResponse(response)
                 case .failure(let error):
-                    print("[ERROR] Token refresh network error: \(error.localizedDescription)")
+                    print("[ERROR] Refresh request failed: \(error.localizedDescription)")
                     self.completeRefresh(success: false)
                 }
             }
+
         } catch {
-            print("[ERROR] Failed to load refresh token from Keychain: \(error.localizedDescription)")
+            print("[ERROR] Failed to load refresh token: \(error.localizedDescription)")
             completeRefresh(success: false)
         }
     }
 
-    private func retryMoyaRequest(target: TargetType) {
-        guard let moyaTarget = target as? UserInfoTargetType else {
-            print("[ERROR] Unable to retry request - invalid TargetType")
+    private func processRefreshResponse(_ response: Response) {
+        guard (200..<300).contains(response.statusCode) else {
+            print("[ERROR] Token refresh failed with status code: \(response.statusCode)")
+            completeRefresh(success: false)
             return
         }
 
-        let provider = MoyaProvider<UserInfoTargetType>(plugins: [self])
-
-        provider.request(moyaTarget) { result in
-            switch result {
-            case .success(let response):
-                print("[INFO] Retry request successful with status code: \(response.statusCode)")
-            case .failure(let error):
-                print("[ERROR] Retry request failed: \(error.localizedDescription)")
-            }
+        do {
+            let decoded = try JSONDecoder().decode(NewAccessTokenResponse.self, from: response.data)
+            try keychain.saveAccessToken(decoded.data.accessToken)
+            try keychain.saveRefreshToken(decoded.data.refreshToken)
+            print("[INFO] Access token refreshed successfully.")
+            completeRefresh(success: true)
+        } catch {
+            print("[ERROR] Failed to decode token refresh response: \(error)")
+            completeRefresh(success: false)
         }
     }
 
@@ -113,34 +85,38 @@ final class TokenRefreshPlugin: PluginType {
     }
 }
 
-extension TargetType {
-    func asURLRequest() throws -> URLRequest {
-        let url = try self.baseURL.appendingPathComponent(self.path)
-        var request = URLRequest(url: url)
-        request.httpMethod = self.method.rawValue
+//MARK: 일단 만들긴 했지만 지금 사용은 하지 않음 위 로직으로만 동작
+// provider.requestWithTokenRefresh로 호출해야 아래 로직이 돌아감
+extension MoyaProvider {
+    func requestWithTokenRefresh(
+        _ target: Target,
+        retryCount: Int = 1,
+        completion: @escaping (Result<Response, MoyaError>) -> Void
+    ) {
+        self.request(target) { [weak self] result in
+            guard let self else { return }
 
-        switch self.task {
-        case .requestParameters(let parameters, let encoding):
-            request = try encoding.encode(request, with: parameters)
-        case .requestJSONEncodable(let encodable):
-            request.httpBody = try JSONEncoder().encode(encodable)
-        default:
-            break
+            switch result {
+            case .success(let response):
+                if response.statusCode == 401 && retryCount > 0 {
+                    print("🔄 [Moya] 401 detected, refreshing token...")
+
+                    TokenRefreshPlugin().handleTokenRefresh { success in
+                        if success {
+                            print("✅ Retry after refresh")
+                            self.requestWithTokenRefresh(target, retryCount: retryCount - 1, completion: completion)
+                        } else {
+                            print("❌ Token refresh failed")
+                            completion(.failure(.underlying(NSError(domain: "Token refresh failed", code: 401), nil)))
+                        }
+                    }
+                } else {
+                    completion(.success(response))
+                }
+
+            case .failure(let error):
+                completion(.failure(error))
+            }
         }
-
-        self.headers?.forEach { request.setValue($1, forHTTPHeaderField: $0) }
-        return request
     }
 }
-
-/*
- // 인증이 필요없는 API (로그인, 회원가입 등)
- let provider = MoyaProvider<LoginTargetType>(plugins: [MoyaPlugin.shared])
- 
- // 인증이 필요한 API
- let authenticatedProvider = MoyaProvider<UserTargetType>(
- plugins: [MoyaPlugin.shared, TokenRefreshPlugin()]
- )
- */
-
-

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
@@ -85,8 +85,6 @@ final class TokenRefreshPlugin: PluginType {
     }
 }
 
-//MARK: 일단 만들긴 했지만 지금 사용은 하지 않음 위 로직으로만 동작
-// provider.requestWithTokenRefresh로 호출해야 아래 로직이 돌아감
 extension MoyaProvider {
     func requestWithTokenRefresh(
         _ target: Target,

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/DTO/Response /NewAccessTokenResponse.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/DTO/Response /NewAccessTokenResponse.swift
@@ -7,8 +7,12 @@
 
 import Foundation
 
-struct NewAccessTokenResponse: Codable {
+struct NewAccessTokenResponse: Decodable {
+    let message: String
+    let data: TokenData
+}
+
+struct TokenData: Decodable {
     let accessToken: String
     let refreshToken: String
-    let isNewUser: Bool
 }

--- a/Memento-iOS/Memento-iOS/Source/Network/ToDoList/ToDoListAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/ToDoList/ToDoListAPIService.swift
@@ -19,7 +19,7 @@ protocol ToDoListAPIServiceProtocol {
 
 final class ToDoListAPIService: BaseAPIService, ToDoListAPIServiceProtocol {
     
-    private let provider = MoyaProvider<ToDoListTargetType>(plugins: [MoyaPlugin.shared])
+    private let provider = MoyaProvider<ToDoListTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
     
     // To-Do List API 연결
     func getToDoList(completion: @escaping (NetworkResult<BaseDTO<ToDoListTotalResponseData>>) -> Void) {

--- a/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoAPIService.swift
@@ -24,7 +24,7 @@ protocol TodoAPIServiceProtocol {
 
 final class TodoAPIService: BaseAPIService, TodoAPIServiceProtocol {
 
-    private let provider = MoyaProvider<TodoTargetType>(plugins: [MoyaPlugin.shared])
+    private let provider = MoyaProvider<TodoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
 
     func deleteTodo(todoId: Int, completion: @escaping (NetworkResult<Void>) -> Void) {
         provider.request(.deleteTodo(todoId: todoId)) { result in


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
토큰 만료로 인한 리프래쉬 토큰으로 토큰 갱신 처리 에러를 해결

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
🔷 Moya의 PluginType이란?
Moya에서 제공하는 PluginType은 네트워크 요청의 전후 과정에 개입할 수 있는 인터셉터 역할을 하는 프로토콜입니다.
요청 직전 / 직후 / 실패 시 / 응답 수신 후 등 다양한 시점에 대응 가능
로깅, 헤더 추가, 인증 만료 처리, 공통 에러 핸들링 등에서 자주 사용됨
이번 PR에서는 401 Unauthorized가 발생했을 때, Refresh Token으로 Access Token을 재발급받기 위해 사용


### TokenRefreshPlugin 도입
- `Moya.PluginType`을 사용해 `401 Unauthorized` 응답 발생 시 자동으로 Refresh Token을 이용한 재발급을 수행합니다.
- 내부적으로 중복 토큰 갱신을 방지하기 위해 큐(`refreshQueue`)를 두어 `isRefreshing` 상태를 관리합니다.
- 현재 Moya plugin은 자동 재요청은 불가능하여, 외부에서 `requestWithTokenRefresh`를 사용하면 자동 재시도까지 가능합니다.
- 추후 전체 요청이 해당 유틸을 통해 수행되도록 통합할 수 있습니다.

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->


✅ 전체 구조 요약
```swift
TokenRefreshPlugin
├─ didReceive(): 401 응답 감지
├─ handleTokenRefresh(): 토큰 갱신 요청 수행
│  └─ processRefreshResponse(): 응답 처리 및 키체인 저장
├─ refreshQueue: 중복 요청 시 큐에 쌓음
└─ completeRefresh(): 콜백 처리 및 상태 초기화
MoyaProvider+Extension
└─ requestWithTokenRefresh(): 요청 재시도 가능한 유틸 (현재 미사용 상태)
```


🧩 코드 블럭별 설명
✅ 1. didReceive() – 401 감지 진입점
```swift
func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
    guard case let .success(response) = result, response.statusCode == 401 else { return }

    print("🔐 [TokenRefreshPlugin] 401 detected. Starting refresh...")

    handleTokenRefresh { success in
        print(success ? "✅ Token refreshed." : "❌ Token refresh failed.")
        // 재시도는 외부에서 해야 함
    }
}
```
🔹 역할:
서버 응답이 성공(.success)인데 401(만료)인 경우만 감지
바로 handleTokenRefresh()를 호출해 토큰 갱신 시도
주의: 여기서는 자동 재시도는 불가능, 외부에서 다시 요청해야 함


✅ 2. handleTokenRefresh() – 토큰 재발급 요청 시작
```swift
func handleTokenRefresh(completion: @escaping (Bool) -> Void)
```
🔹 역할:
이미 갱신 중이면 refreshQueue에 콜백을 넣고 리턴 (동시 요청 막기)
refreshToken을 키체인에서 꺼냄
갱신 API(/auth/token/refresh)를 호출
결과에 따라 내부 처리 진행 (processRefreshResponse())

✅ 3. processRefreshResponse() – 토큰 갱신 응답 처리

```swift
private func processRefreshResponse(_ response: Response)
```
🔹 역할:
응답이 200대면 파싱 시도
파싱된 accessToken, refreshToken을 키체인에 저장
실패 시 로그 출력
모든 경우에 completeRefresh(success:) 호출하여 큐에 쌓인 콜백 처리

✅ 4. completeRefresh() – 상태 초기화 및 콜백 처리
```swift
private func completeRefresh(success: Bool)
```
🔹 역할:

isRefreshing 상태 false로 초기화
큐에 쌓여 있던 모든 요청의 콜백을 실행
큐 초기화

✅ 5. MoyaProvider 확장 – 재시도 가능한 요청 유틸 (현재 미사용)
```swift
func requestWithTokenRefresh(_ target: Target, retryCount: Int = 1, ...)
```
🔹 역할:

일반 요청을 수행
401 감지되면 handleTokenRefresh() 호출
토큰 갱신 성공 시 자동 재요청 수행
실패 시 에러 반환

📌 현재 프로젝트 내에서 사용되지 않음


사용방법은 "TodoAPIService 토큰 갱신 플러그인 삽입" 커밋 보기 토큰을 사용하는 코드에 무조건 해당 플러그인 추가 해줘야함


추가적으로
requestWithTokenRefresh는 일단 만들긴 했지만 지금 사용은 하지 않음 위 로직으로만 동작
provider.requestWithTokenRefresh로 호출해야 아래 로직이 돌아감
```swift

extension MoyaProvider {
    func requestWithTokenRefresh(
        _ target: Target,
        retryCount: Int = 1,
        completion: @escaping (Result<Response, MoyaError>) -> Void
    ) {
        self.request(target) { [weak self] result in
            guard let self else { return }

            switch result {
            case .success(let response):
                if response.statusCode == 401 && retryCount > 0 {
                    print("🔄 [Moya] 401 detected, refreshing token...")

                    TokenRefreshPlugin().handleTokenRefresh { success in
                        if success {
                            print("✅ Retry after refresh")
                            self.requestWithTokenRefresh(target, retryCount: retryCount - 1, completion: completion)
                        } else {
                            print("❌ Token refresh failed")
                            completion(.failure(.underlying(NSError(domain: "Token refresh failed", code: 401), nil)))
                        }
                    }
                } else {
                    completion(.success(response))
                }

            case .failure(let error):
                completion(.failure(error))
            }
        }
    }
}

```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #20 
