### PR TITLE
[Fix] #30 - 토큰 갱신 버그

### DIFF
--- a/Memento-iOS/Memento-iOS.xcodeproj/project.pbxproj
+++ b/Memento-iOS/Memento-iOS.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 				Source/Const/TimeInterval.swift,
 				Source/Data/MCalendarEventList.swift,
 				Source/Data/MEventDataSource.swift,
+				"Source/Extension/String+.swift",
 				Source/Network/AI/DTO/Request/PrioritizationRequest.swift,
 				Source/Network/AI/DTO/Response/PrioritizationResponse.swift,
 				Source/Network/AI/PrioritizationAPIService.swift,

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -34,7 +34,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct MementoApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @StateObject private var onboardingViewModel = OnboardingViewModel(authViewModel: AuthViewModel())
-    private var appState = AppState()
+    @StateObject private var appState = AppState.shared
     @State var showLottieAnimation: Bool = true
     
     var body: some Scene {

--- a/Memento-iOS/Memento-iOS/Source/Extension/String+.swift
+++ b/Memento-iOS/Memento-iOS/Source/Extension/String+.swift
@@ -1,0 +1,16 @@
+//
+//  String+.swift
+//  Memento-iOS
+//
+//  Created by RAFA on 4/10/25.
+//
+
+import Foundation
+
+extension String {
+
+    func base64Padded() -> String {
+        let padding = 4 - count % 4
+        return self + String(repeating: "=", count: padding % 4)
+    }
+}

--- a/Memento-iOS/Memento-iOS/Source/Network/AI/PrioritizationAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/AI/PrioritizationAPIService.swift
@@ -21,12 +21,10 @@ extension PrioritizationAPIServiceProtocol {
 // MARK: - PrioritizationAPIService
 
 final class PrioritizationAPIService: BaseAPIService, PrioritizationAPIServiceProtocol {
-    private let provider = MoyaProvider<PrioritizationTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
+    private let provider = MoyaProvider<PrioritizationTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin.shared])
 
     func fetchPrioritization(request: PrioritizationRequest, completion: @escaping (NetworkResult<PrioritizationResponse>) -> Void) {
-        provider.request(.todo(request: request)) { [weak self] result in
-            guard let self = self else { return }
-
+        provider.requestWithTokenRefresh(.todo(request: request)) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<PrioritizationResponse> = self.fetchNetworkResult(

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/TokenKeychainManager.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/TokenKeychainManager.swift
@@ -113,13 +113,23 @@ final class TokenKeychainManager {
     }
     
     // MARK: - Token Validation
-    
+
+    func isTokenExpired(_ token: String) -> Bool {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3,
+              let payloadData = Data(base64Encoded: String(parts[1]).base64Padded()),
+              let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+              let exp = json["exp"] as? TimeInterval else { return true }
+
+        return Date().timeIntervalSince1970 > exp
+    }
+
     func hasValidToken() -> Bool {
         do {
-            if let accessToken = try getAccessToken(), !accessToken.isEmpty {
-                return true
+            guard let accessToken = try getAccessToken(), !accessToken.isEmpty else {
+                return false
             }
-            return false
+            return !isTokenExpired(accessToken)
         } catch {
             return false
         }

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
@@ -8,6 +8,7 @@ import Foundation
 import Moya
 
 final class TokenRefreshPlugin: PluginType {
+    static let shared = TokenRefreshPlugin()
     private let keychain = TokenKeychainManager.shared
     private let provider = MoyaProvider<TokenRefreshType>(plugins: [MoyaPlugin.shared])
     private var isRefreshing = false
@@ -99,7 +100,7 @@ extension MoyaProvider {
                 if response.statusCode == 401 && retryCount > 0 {
                     print("🔄 [Moya] 401 detected, refreshing token...")
 
-                    TokenRefreshPlugin().handleTokenRefresh { success in
+                    TokenRefreshPlugin.shared.handleTokenRefresh { success in
                         if success {
                             print("✅ Retry after refresh")
                             self.requestWithTokenRefresh(target, retryCount: retryCount - 1, completion: completion)

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/TokenRefreshPlugin.swift
@@ -42,7 +42,7 @@ final class TokenRefreshPlugin: PluginType {
                 return
             }
 
-            provider.request(.auth(refreshToken: refreshToken)) { [weak self] result in
+            provider.requestWithTokenRefresh(.auth(refreshToken: refreshToken)) { [weak self] result in
                 guard let self else { return }
 
                 switch result {

--- a/Memento-iOS/Memento-iOS/Source/Network/Health/HealthCheckAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Health/HealthCheckAPIService.swift
@@ -27,7 +27,7 @@ final class HealthCheckAPIService: BaseAPIService, HealthCheckAPIServiceProtocol
 
     /// Health Check API 호출
     func getHealthCheck(completion: @escaping (NetworkResult<HealthCheckResponseDTO>) -> Void) {
-        provider.request(.getHealthCheck) { result in
+        provider.requestWithTokenRefresh(.getHealthCheck) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<HealthCheckResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/AppleSchedulesAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/AppleSchedulesAPIService.swift
@@ -17,7 +17,7 @@ protocol AppleSchedulesAPIServiceProtocol {
 // MARK: - AppleSchedulesAPIService
 
 final class AppleSchedulesAPIService: BaseAPIService, AppleSchedulesAPIServiceProtocol {
-    private let provider = MoyaProvider<AppleSchedulesTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
+    private let provider = MoyaProvider<AppleSchedulesTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin.shared])
 
     /// 스케줄 생성하기 API 호출
     func submitSchedules(request: AppleScheduleListRequest, completion: @escaping (NetworkResult<EmptyDTO>) -> Void) {

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/UserInfoAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/UserInfoAPIService.swift
@@ -18,11 +18,11 @@ protocol UserInfoAPIServiceProtocol {
 
 final class UserInfoAPIService: BaseAPIService, UserInfoAPIServiceProtocol {
 
-    private let provider = MoyaProvider<UserInfoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
+    private let provider = MoyaProvider<UserInfoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin.shared])
 
     /// 사용자 정보 업데이트 API 호출
     func updateUserInfo(request: UserInfoRequest, completion: @escaping (NetworkResult<EmptyDTO>) -> Void) {
-        provider.request(.updateUserInfo(request: request)) { [weak self] result in
+        provider.requestWithTokenRefresh(.updateUserInfo(request: request)) { [weak self] result in
             guard let self = self else { return }
 
             switch result {

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/UserUptimeAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/UserUptimeAPIService.swift
@@ -21,10 +21,10 @@ extension UserUptimeAPIServiceProtocol {
 // MARK: - UserInfoGetAPIService
 
 final class UserUptimeAPIService: BaseAPIService, UserUptimeAPIServiceProtocol {
-    private let provider = MoyaProvider<UserInfoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
+    private let provider = MoyaProvider<UserInfoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin.shared])
 
     func fetchUptime(completion: @escaping (NetworkResult<UserUptimeResponseDTO>) -> Void) {
-        provider.request(.getUserUptime) { [weak self] result in
+        provider.requestWithTokenRefresh(.getUserUptime) { [weak self] result in
             guard let self = self else { return }
 
             switch result {

--- a/Memento-iOS/Memento-iOS/Source/Network/Schedule/ScheduleAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Schedule/ScheduleAPIService.swift
@@ -36,7 +36,7 @@ final class ScheduleAPIService: BaseAPIService, ScheduleAPIServiceProtocol {
     
     // 일정(Schedule) 관련 전체 데이터 
     func getSchedulesTotal(completion: @escaping (NetworkResult<BaseDTO<ScheduleTotalResponseData>>) -> Void) {
-        provider.request(.getSchedulesTotal) { [weak self] result in
+        provider.requestWithTokenRefresh(.getSchedulesTotal) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let response):
@@ -53,7 +53,7 @@ final class ScheduleAPIService: BaseAPIService, ScheduleAPIServiceProtocol {
     
     // 일정 All-day API 연결
     func getSchedulesAllDays(completion: @escaping (NetworkResult<ScheduleAllDayResponseDTO>) -> Void) {
-        provider.request(.getSchedulesAllDay) { result in
+        provider.requestWithTokenRefresh(.getSchedulesAllDay) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<ScheduleAllDayResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
@@ -71,7 +71,7 @@ final class ScheduleAPIService: BaseAPIService, ScheduleAPIServiceProtocol {
     
     // 일정 (해당 날짜) API 연결 
     func getSchedules(completion: @escaping (NetworkResult<ScheduleResponseDTO>) -> Void) {
-        provider.request(.getSchedules) { result in
+        provider.requestWithTokenRefresh(.getSchedules) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<ScheduleResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
@@ -89,7 +89,7 @@ final class ScheduleAPIService: BaseAPIService, ScheduleAPIServiceProtocol {
     
     // 일정 (디테일) API 연결 
     func getSchedulesDetail(completion: @escaping (NetworkResult<ScheduleDetailResponseDTO>) -> Void) {
-        provider.request(.getSchedulesDetail) { result in
+        provider.requestWithTokenRefresh(.getSchedulesDetail) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<ScheduleDetailResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
@@ -107,7 +107,7 @@ final class ScheduleAPIService: BaseAPIService, ScheduleAPIServiceProtocol {
     
     func postCreateSchedule(bodyParam: PostCreateScheduleRequest,
                             completion: @escaping (NetworkResult<PostCreateScheduleResponseDTO>) -> Void) {
-        provider.request(.postCreateSchedule(body: bodyParam),
+        provider.requestWithTokenRefresh(.postCreateSchedule(body: bodyParam),
                          completion: { [weak self] result in
             guard let self else { return }
             switch result {
@@ -127,7 +127,7 @@ final class ScheduleAPIService: BaseAPIService, ScheduleAPIServiceProtocol {
     }
 
     func deleteSchedule(scheduleId: Int, completion: @escaping (NetworkResult<Void>) -> Void) {
-        provider.request(.deleteSchedule(scheduleId: scheduleId)) { result in
+        provider.requestWithTokenRefresh(.deleteSchedule(scheduleId: scheduleId)) { result in
             print("DEBUG: Requesting DELETE for Schedule ID: \(scheduleId)")
             switch result {
             case .success(let response):

--- a/Memento-iOS/Memento-iOS/Source/Network/Tag/TagAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Tag/TagAPIService.swift
@@ -26,7 +26,7 @@ final class TagAPIService: BaseAPIService, TagAPIServiceProtocol {
     private let provider = MoyaProvider<TagTargetType>(plugins: [MoyaPlugin.shared])
     
     func getTags(completion: @escaping (NetworkResult<BaseDTO<[TagResponseData]>>) -> Void) {
-        provider.request(.getTags) { result in
+        provider.requestWithTokenRefresh(.getTags) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<BaseDTO<[TagResponseData]>> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)

--- a/Memento-iOS/Memento-iOS/Source/Network/ToDoList/ToDoListAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/ToDoList/ToDoListAPIService.swift
@@ -19,11 +19,11 @@ protocol ToDoListAPIServiceProtocol {
 
 final class ToDoListAPIService: BaseAPIService, ToDoListAPIServiceProtocol {
     
-    private let provider = MoyaProvider<ToDoListTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
+    private let provider = MoyaProvider<ToDoListTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin.shared])
     
     // To-Do List API 연결
     func getToDoList(completion: @escaping (NetworkResult<BaseDTO<ToDoListTotalResponseData>>) -> Void) {
-        provider.request(.getToDoList) { result in
+        provider.requestWithTokenRefresh(.getToDoList) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<BaseDTO<ToDoListTotalResponseData>> = self.fetchNetworkResult(
@@ -46,7 +46,7 @@ final class ToDoListAPIService: BaseAPIService, ToDoListAPIServiceProtocol {
     
     // To-Do List 완료 여부 API 연결
     func updateToDoCompletion(toDoId: Int, completion: @escaping (NetworkResult<BaseDTO<ToDoListCompletedResponseData>>) -> Void) {
-        provider.request(.updateToDoCompletion(toDoId: toDoId)) { result in
+        provider.requestWithTokenRefresh(.updateToDoCompletion(toDoId: toDoId)) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<BaseDTO<ToDoListCompletedResponseData>> = self.fetchNetworkResult(

--- a/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoAPIService.swift
@@ -24,10 +24,10 @@ protocol TodoAPIServiceProtocol {
 
 final class TodoAPIService: BaseAPIService, TodoAPIServiceProtocol {
 
-    private let provider = MoyaProvider<TodoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin()])
+    private let provider = MoyaProvider<TodoTargetType>(plugins: [MoyaPlugin.shared, TokenRefreshPlugin.shared])
 
     func deleteTodo(todoId: Int, completion: @escaping (NetworkResult<Void>) -> Void) {
-        provider.request(.deleteTodo(todoId: todoId)) { result in
+        provider.requestWithTokenRefresh(.deleteTodo(todoId: todoId)) { result in
             print("DEBUG: Requesting DELETE for Todo ID: \(todoId)")
             switch result {
             case .success(let response):
@@ -57,7 +57,7 @@ final class TodoAPIService: BaseAPIService, TodoAPIServiceProtocol {
         priorityImportance: Double?,
         completion: @escaping (NetworkResult<Void>) -> Void
     ) {
-        provider.request(
+        provider.requestWithTokenRefresh(
             .createTodo(
                 startDate: startDate,
                 description: description,

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AppState.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AppState.swift
@@ -11,11 +11,6 @@ class AppState: ObservableObject {
     @Published var isLoggedIn: Bool = false
     
     init() {
-//        do {
-//            try TokenKeychainManager.shared.clearTokens()
-//        } catch {
-//            
-//        }
         checkToken()
     }
     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AppState.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AppState.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 class AppState: ObservableObject {
+
+    static let shared = AppState()
+
     @Published var isLoggedIn: Bool = false
     
     init() {

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AppState.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AppState.swift
@@ -21,13 +21,87 @@ class AppState: ObservableObject {
         do {
             // AccessToken 확인
             if let accessToken = try TokenKeychainManager.shared.getAccessToken(), !accessToken.isEmpty {
+                debugPrintTokenPayload(accessToken)
                 isLoggedIn = true
             } else {
                 isLoggedIn = false
             }
         } catch {
-            print("토큰 확인 실패: \(error.localizedDescription)")
+            print("DEBUG: 토큰 확인 실패 >>> \(error.localizedDescription)")
             isLoggedIn = false
+        }
+    }
+}
+
+private extension AppState {
+
+    /// JWT 토큰의 Payload를 디코딩하여 콘솔에 디버깅 출력합니다.
+    ///
+    /// 이 함수는 전달된 JWT 문자열을 파싱하여 payload 부분(base64 인코딩된 JSON)을 추출하고,
+    /// 이를 디코딩하여 Payload 내부의 key-value 구조를 콘솔에 출력합니다.
+    ///
+    /// `exp` 필드가 존재할 경우, 해당 만료 시간을 Date로 변환하여 사람이 읽을 수 있는 형식으로 함께 출력합니다.
+    ///
+    /// - Parameter token: JWT 형식의 액세스 토큰 문자열 (`header.payload.signature` 형식)
+    ///
+    /// - Note:
+    ///    - JWT는 3개의 base64 인코딩된 문자열로 구성되어야 하며, payload는 JSON 구조여야 합니다.
+    ///    - payload는 base64 URL-safe 포맷이기 때문에 `=` 패딩이 누락될 수 있으며,
+    ///      이를 보정하기 위해 `base64Padded()`를 사용합니다.
+    ///
+    /// - Warning:
+    ///    - `token`이 올바르지 않은 형식이거나 payload 디코딩에 실패할 경우,
+    ///      적절한 디버깅 메시지가 출력되며 함수는 조용히 종료됩니다.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let token = "eyJhbGci~.eyJzdWIiOi~.SflKxwRJSMeKK~V_adQ~"
+    /// debugPrintTokenPayload(token)
+    /// ```
+    ///
+    /// - Output:
+    /// ```
+    /// DEBUG: JWT Payload >>>
+    /// DEBUG: - iat: 1744269500
+    /// DEBUG: - exp: 1744206900
+    /// DEBUG: - sub: 123
+    /// DEBUG: exp 존재함 >>> 1744206900.0 (2025-04-10 17:35:00)
+    /// ```
+    func debugPrintTokenPayload(_ token: String) {
+        let parts = token.split(separator: ".")
+
+        guard parts.count == 3 else {
+            print("DEBUG: JWT 구조가 올바르지 않습니다.")
+            return
+        }
+
+        let payloadBase64 = String(parts[1]).base64Padded()
+
+        guard let payloadData = Data(base64Encoded: payloadBase64) else {
+            print("DEBUG: payload base64 디코딩 실패")
+            return
+        }
+
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: payloadData),
+              let json = jsonObject as? [String: Any] else {
+            print("DEBUG: payload JSON 파싱 실패")
+            return
+        }
+
+        print("DEBUG: JWT Payload >>>")
+        for (key, value) in json {
+            print("DEBUG: - \(key): \(value)")
+        }
+
+        if let exp = json["exp"] as? TimeInterval {
+            let date = Date(timeIntervalSince1970: exp)
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+            formatter.timeZone = .current
+
+            print("DEBUG: exp 존재함 >>> \(exp) (\(formatter.string(from: date)))")
+        } else {
+            print("DEBUG: exp 필드 없음")
         }
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
1. `TokenRefreshPlugin`을 싱글톤 패턴으로 변경
2. API 요청 방식 변경
3. `@StateObject`로 감싸기
4. JWT 만료 여부를 `exp` 기반으로 정밀 검사

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
[트러블 슈팅](https://www.notion.so/testmanzi/1d067bb5c6cf80f2a3cee9c67f450f94?pvs=4)

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
### `TokenKeychainManager`
```swift
func isTokenExpired(_ token: String) -> Bool {
    let parts = token.split(separator: ".")
    guard parts.count == 3,
          let payloadData = Data(base64Encoded: String(parts[1]).base64Padded()),
          let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
          let exp = json["exp"] as? TimeInterval else { return true }

    return Date().timeIntervalSince1970 > exp
}

extension String {

    func base64Padded() -> String {
        let padding = 4 - count % 4
        return self + String(repeating: "=", count: padding % 4)
    }
}
```
- JWT payload에 포함된 `exp` 값 기반으로 **만료 시간 정밀 파싱**
- Base64 URL-safe 문자열의 길이 보정까지 처리
- `hasValidToken()` 등 여러 검증 함수에서 활용 가능

### `isTokenExpired()` 메서드 분석

1. JWT 문자열 분리
    
    `header.payload.signature`에서 `payload`만 추출
    
    ```swift
    let parts = token.split(separator: ".") // ["header", "payload", "signature"]
    let payload = parts[1]
    ```
    
2. base64 디코딩 전 패딩 복구
    
    ```swift
    let payloadData = Data(base64Encoded: String(parts[1]).base64Padded())
    ```
    
    - JWT는 base64 URL-safe 인코딩이므로 padding(`=`)이 종종 생략되어 있음
    - 이를 복구하는 게 `base64Padded()` 역할
        
        ```swift
        extension String {
        
            func base64Padded() -> String {
                let padding = 4 - count % 4
                return self + String(repeating: "=", count: padding % 4)
            }
        }
        ```
        
        - base64 인코딩 문자열은 길이가 **4의 배수**여야 정상적으로 디코딩됨
        - 패딩이 부족할 경우, `=`을 추가해줌
3. JSON 파싱
    
    ```swift
    let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any]
    ```
    
    - 디코딩된 payload(base64 → Data)를 **JSON 딕셔너리로 변환**
4. `exp` 추출 및 비교
    
    ```swift
    let exp = json["exp"] as? TimeInterval
    return Date().timeIntervalSince1970 > exp
    ```
    
    - 현재 시간(`timeIntervalSince1970`)이 `exp`보다 크면 **만료됨 → true 반환**

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈
- Resolved: #30 