### PR TITLE
[Fix] #26 - ToDo 생성 버그

### DIFF
--- a/Memento-iOS/Memento-iOS.xcodeproj/project.pbxproj
+++ b/Memento-iOS/Memento-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		8351D78B2D305724008336BE /* MDSKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8351D78A2D305724008336BE /* MDSKit */; };
 		8351D78E2D30575E008336BE /* MDSKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8351D78D2D30575E008336BE /* MDSKit */; };
 		839405562D2D041300F3A2CF /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 839405552D2D041300F3A2CF /* Moya */; };
+		9D9DABEE2E44C17400DDD832 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 9D9DABED2E44C17400DDD832 /* FirebaseMessaging */; };
 		9DBC14972D36434200A022A9 /* MCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = 9DBC14962D36434200A022A9 /* MCalendar */; };
 		9DBD045A2D4315270045DD70 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9DBD04592D4315270045DD70 /* Lottie */; };
 /* End PBXBuildFile section */
@@ -124,6 +125,7 @@
 			files = (
 				2F459C3E2D37C88600EDD537 /* GoogleSignIn in Frameworks */,
 				9DBC14972D36434200A022A9 /* MCalendar in Frameworks */,
+				9D9DABEE2E44C17400DDD832 /* FirebaseMessaging in Frameworks */,
 				9DBD045A2D4315270045DD70 /* Lottie in Frameworks */,
 				8351D78E2D30575E008336BE /* MDSKit in Frameworks */,
 				8351D78B2D305724008336BE /* MDSKit in Frameworks */,
@@ -200,6 +202,7 @@
 				2F459C422D37C91B00EDD537 /* FirebaseCore */,
 				9DBC14962D36434200A022A9 /* MCalendar */,
 				9DBD04592D4315270045DD70 /* Lottie */,
+				9D9DABED2E44C17400DDD832 /* FirebaseMessaging */,
 			);
 			productName = "Memento-iOS";
 			productReference = 830F3C562D2A73BD00254FDE /* Memento-iOS.app */;
@@ -569,6 +572,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 839405542D2D041200F3A2CF /* XCRemoteSwiftPackageReference "Moya" */;
 			productName = Moya;
+		};
+		9D9DABED2E44C17400DDD832 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F459C392D37C83800EDD537 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 		9DBC14962D36434200A022A9 /* MCalendar */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Memento-iOS/Memento-iOS/Memento-iOS.entitlements
+++ b/Memento-iOS/Memento-iOS/Memento-iOS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/Memento-iOS/Memento-iOS/Memento-iOSRelease.entitlements
+++ b/Memento-iOS/Memento-iOS/Memento-iOSRelease.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -11,18 +11,48 @@ import FirebaseCore
 import GoogleSignIn
 import MDSKit
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+import Firebase
+import FirebaseMessaging
+import UserNotifications
+
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+
         registerFonts()
         FirebaseApp.configure()
+
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("알림 권한 요청 실패: \(error.localizedDescription)")
+                return
+            }
+            if granted {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            } else {
+                print("알림 권한 거부")
+            }
+        }
+
         Thread.sleep(forTimeInterval: 2)
         return true
     }
-    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        return UIInterfaceOrientationMask.portrait
+
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        print("APNs 디바이스 토큰 등록 성공")
+        Messaging.messaging().apnsToken = deviceToken
     }
-    
+
+    func application(_ application: UIApplication,
+                     didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("APNs 디바이스 토큰 등록 실패: \(error.localizedDescription)")
+    }
+
     func application(_ app: UIApplication,
                      open url: URL,
                      options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -41,12 +71,15 @@ struct MementoApp: App {
         WindowGroup {
             if showLottieAnimation {
                 SplashScreenView(showLottieAnimation: $showLottieAnimation)
+                    .preferredColorScheme(.dark)
             } else {
                 if appState.isLoggedIn {
                     TabBarView()
+                        .preferredColorScheme(.dark)
                 } else {
                     LoginView()
                         .environmentObject(onboardingViewModel)
+                        .preferredColorScheme(.dark)
                 }
             }
         }

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -22,21 +22,23 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
         registerFonts()
         FirebaseApp.configure()
-
+        Messaging.messaging().isAutoInitEnabled = true
+        Messaging.messaging().apnsToken = Data(repeating: 0, count: 32)
         UNUserNotificationCenter.current().delegate = self
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-            if let error = error {
-                print("알림 권한 요청 실패: \(error.localizedDescription)")
-                return
-            }
-            if granted {
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
-            } else {
-                print("알림 권한 거부")
-            }
-        }
+        
+//        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+//            if let error = error {
+//                print("알림 권한 요청 실패: \(error.localizedDescription)")
+//                return
+//            }
+//            if granted {
+//                DispatchQueue.main.async {
+//                    UIApplication.shared.registerForRemoteNotifications()
+//                }
+//            } else {
+//                print("알림 권한 거부")
+//            }
+//        }
 
         Thread.sleep(forTimeInterval: 2)
         return true

--- a/Memento-iOS/Memento-iOS/Source/Component/TabBar/TabBarView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Component/TabBar/TabBarView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 import MCalendar
 
 struct TabBarView: View {
-
+    
     @State private var selectedTab: TabBarItem = .today
     @State private var previousTab: TabBarItem = .today
     @State private var segmentedViewHeight: CGFloat = .zero
     @GestureState private var translation: CGFloat = .zero
-
+    
     @StateObject var segmentedViewModel = SegmentedMenuViewModel()
     @StateObject var calendarViewModel = WeeklyCalendarViewModel(
         mCalendarDataSource: MCalendarDataSource(),
@@ -59,7 +59,11 @@ struct TabBarView: View {
                         segmentedViewModel.isPresented = true
                         selectedTab = previousTab
                     }
-                    .onChange(of: selectedTab) { _, newValue in
+                    .onChange(of: selectedTab) { oldValue, newValue in
+                        if newValue != .addition {
+                            previousTab = newValue
+                        }
+                        
                         if newValue == .addition {
                             withAnimation {
                                 segmentedViewModel.isPresented = true
@@ -76,7 +80,7 @@ struct TabBarView: View {
                     }
                     .tag(TabBarItem.todo)
             }
-
+            
             if segmentedViewModel.isPresented {
                 Color.black.opacity(0.5)
                     .ignoresSafeArea(.all)
@@ -86,7 +90,7 @@ struct TabBarView: View {
                         segmentedViewModel.selectedButton = .checkbox
                     }
                     .zIndex(1)
-
+                
                 SegmentedMenuView(viewModel: segmentedViewModel, sheetHeight: $segmentedViewHeight)
                     .zIndex(2)
                     .offset(y: translation)
@@ -113,10 +117,10 @@ struct TabBarView: View {
             calendarViewModel.getToDoListTotalAPI()
             calendarViewModel.getSchedulesTotalAPI()
             todolistViewModel.getToDoListTotalAPI()
-            
         }
+        .environmentObject(todolistViewModel)
     }
-
+    
     private func dismissKeyboard() {
         UIApplication.shared.sendAction(
             #selector(UIResponder.resignFirstResponder),

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/DTO/Request/LoginRequest.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/DTO/Request/LoginRequest.swift
@@ -10,5 +10,7 @@ import Foundation
 struct LoginRequest: Codable {
     let provider: String // "GOOGLE" 또는 "APPLE"
     let idToken: String  // ID Token : From Firebase Auth
+    let timeZoneOffset: String 
+    let fcmToken: String
 }
 

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/DTO/TargetType/LoginTargetType.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/DTO/TargetType/LoginTargetType.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 enum LoginTargetType {
-    case login(provider: String, idToken: String)
+    case login(provider: String, idToken: String, timeZoneOffset: String, fcmToken: String)
 }
 
 extension LoginTargetType: BaseTargetType {
@@ -23,24 +23,29 @@ extension LoginTargetType: BaseTargetType {
     }
     
     var utilPath: UtilPath {
-        return .auth
+        return .user
     }
     
     var path: String {
         switch self {
         case .login:
-            return "\(utilPath.rawValue)/login" // 결과: "/api/v1/auth/login"
+            return "\(utilPath.rawValue)" // 결과: "/api/v1/members"
         }
     }
     
     var method: Moya.Method {
-        return .post
+        return .put
     }
     
     var requestBodyParameter: Codable? {
         switch self {
-        case .login(let provider, let idToken):
-            return LoginRequest(provider: provider, idToken: idToken)
+        case let .login(provider, idToken, timeZoneOffset, fcmToken):
+            return LoginRequest(
+                provider: provider,
+                idToken: idToken,
+                timeZoneOffset: timeZoneOffset,
+                fcmToken: fcmToken
+            )
         }
     }
     

--- a/Memento-iOS/Memento-iOS/Source/Network/Onboarding/LoginAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Onboarding/LoginAPIService.swift
@@ -11,7 +11,7 @@ import Moya
 // MARK: - LoginAPIServiceProtocol
 
 protocol LoginAPIServiceProtocol {
-    func login(provider: String, idToken: String, completion: @escaping (NetworkResult<LoginResponseDTO>) -> Void)
+    func login(provider: String, idToken: String, timeZoneOffset: String, fcmToken: String, completion: @escaping (NetworkResult<LoginResponseDTO>) -> Void)
 }
 
 extension LoginAPIServiceProtocol {
@@ -25,8 +25,10 @@ final class LoginAPIService: BaseAPIService, LoginAPIServiceProtocol {
     let provider = MoyaProvider<LoginTargetType>(plugins: [MoyaPlugin.shared])
     
     /// 로그인 API 호출
-    func login(provider: String, idToken: String, completion: @escaping (NetworkResult<LoginResponseDTO>) -> Void) {
-        self.provider.request(.login(provider: provider, idToken: idToken)) { [weak self] result in
+    func login(provider: String, idToken: String, timeZoneOffset: String, fcmToken: String, completion: @escaping (NetworkResult<LoginResponseDTO>) -> Void) {
+        self.provider.request(
+            .login(provider: provider, idToken: idToken, timeZoneOffset: timeZoneOffset, fcmToken: fcmToken)
+        ) { [weak self] result in
             guard let self = self else { return }
             
             switch result {
@@ -37,6 +39,19 @@ final class LoginAPIService: BaseAPIService, LoginAPIServiceProtocol {
                 )
                 print(networkResult.stateDescription)
                 completion(networkResult)
+                
+                
+                if case .success(let data) = networkResult,
+                   let loginData = data?.data {
+                    do {
+                        let access = loginData.accessToken.replacingOccurrences(of: "Bearer ", with: "")
+                        let refresh = loginData.refreshToken.replacingOccurrences(of: "Bearer ", with: "")
+                        try TokenKeychainManager.shared.saveAccessToken(access)
+                        try TokenKeychainManager.shared.saveRefreshToken(refresh)
+                    } catch {
+                        print("[ERROR] 토큰 저장 실패: \(error)")
+                    }
+                }
                 
             case .failure(let error):
                 if let response = error.response {
@@ -50,5 +65,3 @@ final class LoginAPIService: BaseAPIService, LoginAPIServiceProtocol {
         }
     }
 }
-
-

--- a/Memento-iOS/Memento-iOS/Source/Network/Todo/DTO/Request/TodoRequest.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Todo/DTO/Request/TodoRequest.swift
@@ -10,8 +10,8 @@ import Foundation
 struct TodoRequest: Codable {
     let startDate: String
     let description: String
-    let endDate: String?
-    let tagId: Int?
-    let priorityUrgency: Double?
-    let priorityImportance: Double?
+    let endDate: String
+    let tagId: Int
+    let priorityUrgency: Double
+    let priorityImportance: Double
 }

--- a/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoAPIService.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoAPIService.swift
@@ -14,10 +14,10 @@ protocol TodoAPIServiceProtocol {
     func createTodo(
         startDate: String,
         description: String,
-        endDate: String?,
-        tagId: Int?,
-        priorityUrgency: Double?,
-        priorityImportance: Double?,
+        endDate: String,
+        tagId: Int,
+        priorityUrgency: Double,
+        priorityImportance: Double,
         completion: @escaping (NetworkResult<Void>) -> Void
     )
 }
@@ -51,10 +51,10 @@ final class TodoAPIService: BaseAPIService, TodoAPIServiceProtocol {
     func createTodo(
         startDate: String,
         description: String,
-        endDate: String?,
-        tagId: Int?,
-        priorityUrgency: Double?,
-        priorityImportance: Double?,
+        endDate: String,
+        tagId: Int,
+        priorityUrgency: Double,
+        priorityImportance: Double,
         completion: @escaping (NetworkResult<Void>) -> Void
     ) {
         provider.requestWithTokenRefresh(

--- a/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoTargetType.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Todo/TodoTargetType.swift
@@ -12,27 +12,27 @@ enum TodoTargetType {
     case createTodo(
         startDate: String,
         description: String,
-        endDate: String?,
-        tagId: Int?,
-        priorityUrgency: Double?,
-        priorityImportance: Double?
+        endDate: String,
+        tagId: Int,
+        priorityUrgency: Double,
+        priorityImportance: Double
     )
 }
 
 extension TodoTargetType: BaseTargetType {
-
+    
     var pathParameter: String? {
         return nil
     }
-
+    
     var headerType: HeaderType {
         return .accessTokenHeader
     }
-
+    
     var utilPath: UtilPath {
         return .todo
     }
-
+    
     var path: String {
         switch self {
         case .deleteTodo(let todoId):
@@ -41,7 +41,7 @@ extension TodoTargetType: BaseTargetType {
             return utilPath.rawValue
         }
     }
-
+    
     var method: Moya.Method {
         switch self {
         case .deleteTodo:
@@ -50,7 +50,7 @@ extension TodoTargetType: BaseTargetType {
             return .post
         }
     }
-
+    
     var requestBodyParameter: Codable? {
         switch self {
         case .deleteTodo:
@@ -73,7 +73,7 @@ extension TodoTargetType: BaseTargetType {
             )
         }
     }
-
+    
     var queryParameter: [String: Any]? {
         return nil
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddSchedule/View/AddScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddSchedule/View/AddScheduleView.swift
@@ -194,7 +194,7 @@ struct AddScheduleView: View {
             .sheet(isPresented: $viewModel.isTagPressed) {
                 TagPickerSheet(
                     viewModel: viewModel,
-                    isPresented: $viewModel.isTagPressed,
+//                    isPresented: $viewModel.isTagPressed,
                     type: .addSchedule(.tag),
                     tagList: Tag.mockData
                 )

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddSchedule/ViewModel/AddScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddSchedule/ViewModel/AddScheduleViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import MDSKit
 
 final class AddScheduleViewModel: ObservableObject, TagSelectable {
-
+   
     // MARK: - Dependencies
 
     private var scheduleApiService: ScheduleAPIService
@@ -37,6 +37,7 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     @Published var isEndDatePressed: Bool = false
     @Published var isEndTimePressed: Bool = false
     @Published var isTagPressed: Bool = false
+    @Published var showTagPicker: Bool = false
 
     @Published var isStartDatePickerPresented: Bool = false
     @Published var isEndDatePickerPresented: Bool = false

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/View/AddTodoKeyboardToolbarItem.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/View/AddTodoKeyboardToolbarItem.swift
@@ -10,10 +10,10 @@ import SwiftUI
 import MDSKit
 
 struct AddTodoKeyboardToolbarItem: View {
-
+    
     @ObservedObject var viewModel: AddTodoViewModel
-    @Environment(\.dismiss) var dismiss
-
+    var onEnter: () -> Void
+    
     var body: some View {
         HStack {
             deadlineButton
@@ -27,14 +27,14 @@ struct AddTodoKeyboardToolbarItem: View {
         .frame(width: UIScreen.main.bounds.width)
         .background(Color.gray10.ignoresSafeArea(.all))
     }
-
+    
     var deadlineButton: some View {
         Button(action: {
             viewModel.showEndDatePicker = true
         }) {
             HStack {
                 Image(.ic_deadline)
-
+                
                 Text(viewModel.formattedEndDate)
                     .applyFont(.detail_r_12)
             }
@@ -47,7 +47,7 @@ struct AddTodoKeyboardToolbarItem: View {
             SheetContainer(type: .addTodo(.date)) {
                 VStack {
                     SheetOKButton { viewModel.showEndDatePicker = false }
-
+                    
                     DatePicker(
                         "",
                         selection: $viewModel.endDate,
@@ -61,7 +61,7 @@ struct AddTodoKeyboardToolbarItem: View {
             }
         }
     }
-
+    
     var tagButton: some View {
         Button(action: {
             viewModel.showTagPicker = true
@@ -76,13 +76,13 @@ struct AddTodoKeyboardToolbarItem: View {
         .sheet(isPresented: $viewModel.showTagPicker) {
             TagPickerSheet(
                 viewModel: viewModel,
-                isPresented: $viewModel.showTagPicker,
+                //                isPresented: $viewModel.showTagPicker,
                 type: .addTodo(.tag),
-                tagList: Tag.mockData
+                tagList: viewModel.tags
             )
         }
     }
-
+    
     var matrixButton: some View {
         Button(action: {
             viewModel.showPriorityPicker = true
@@ -104,13 +104,10 @@ struct AddTodoKeyboardToolbarItem: View {
             }
         }
     }
-
+    
     var enterButton: some View {
         Button(action: {
-            viewModel.createTodo {
-                viewModel.postMakeScheduleNotiFication()
-                dismiss()
-            }
+            onEnter()
         }) {
             Image(viewModel.isTextEmpty ? .btn_enter_disabled : .btn_enter_active)
         }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/View/AddTodoTextView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/View/AddTodoTextView.swift
@@ -9,17 +9,18 @@ import SwiftUI
 import MDSKit
 
 struct AddTodoTextView: View {
-
+    
     // MARK: - Properties
-
+    
     @ObservedObject var viewModel: AddTodoViewModel
-
-    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var todolistViewModel: ToDoListViewModel
+    var onClose: (() -> Void)?
+    
     @FocusState private var isFocused: Bool
     @State private var keyboardHeight: CGFloat = 0
-
+    
     // MARK: - Body
-
+    
     var body: some View {
         VStack {
             ScrollViewReader { proxy in
@@ -56,13 +57,22 @@ struct AddTodoTextView: View {
         }
         .toolbar {
             ToolbarItem(placement: .keyboard) {
-                AddTodoKeyboardToolbarItem(viewModel: viewModel)
+                AddTodoKeyboardToolbarItem(
+                    viewModel: viewModel,
+                    onEnter: {
+                        viewModel.createTodo {
+                            viewModel.postMakeScheduleNotiFication()
+                            todolistViewModel.getToDoListTotalAPI()
+                            onClose?()
+                        }
+                    }
+                )
             }
         }
     }
-
+    
     // MARK: - Helpers
-
+    
     private func setupKeyboardObservers(proxy: ScrollViewProxy) {
         NotificationCenter.default.addObserver(
             forName: UIResponder.keyboardWillShowNotification,
@@ -73,13 +83,13 @@ struct AddTodoTextView: View {
                 UIResponder.keyboardFrameEndUserInfoKey
             ] as? CGRect {
                 keyboardHeight = keyboardFrame.height + 30
-
+                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     scrollToBottom(proxy: proxy)
                 }
             }
         }
-
+        
         NotificationCenter.default.addObserver(
             forName: UIResponder.keyboardWillHideNotification,
             object: nil,
@@ -88,7 +98,7 @@ struct AddTodoTextView: View {
             keyboardHeight = 0
         }
     }
-
+    
     private func scrollToBottom(proxy: ScrollViewProxy) {
         proxy.scrollTo("TextFieldBottomAnchor", anchor: .bottom)
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/View/AddTodoView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/View/AddTodoView.swift
@@ -10,17 +10,19 @@ import SwiftUI
 import MDSKit
 
 struct AddTodoView: View {
-
+    
     // MARK: - Properties
-
+    
     @StateObject private var viewModel = AddTodoViewModel()
-
+    @EnvironmentObject var todolistViewModel: ToDoListViewModel
+    var onClose: (() -> Void)?
+    
     // MARK: - Body
-
+    
     var body: some View {
         VStack {
             AddTodoHeaderView(viewModel: viewModel)
-            AddTodoTextView(viewModel: viewModel)
+            AddTodoTextView(viewModel: viewModel, onClose: onClose)
         }
         .padding(.horizontal)
         .background(Color.gray10)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/ViewModel/AddTodoViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/AddTodo/ViewModel/AddTodoViewModel.swift
@@ -10,38 +10,43 @@ import SwiftUI
 import MDSKit
 
 final class AddTodoViewModel: ObservableObject, TagSelectable {
-
+    
     // MARK: - Properties
-
+    
     @Published var isButtonSelected: Bool = false
-
+    
     @Published var description: String = ""
-
+    
     @Published var showStartDatePicker: Bool = false
     @Published var showEndDatePicker: Bool = false
     @Published var showTagPicker: Bool = false
     @Published var showPriorityPicker: Bool = false
-
+    
     @Published var isNaturalLanguageInputEnabled: Bool = false
-
+    
     @Published var startDate: Date = Date() {
         didSet { updateFormattedDate() }
     }
-
+    
     @Published var endDate: Date = Date() {
         didSet { updateFormattedDate() }
     }
-
+    
     @Published var formattedStartDate: String = StringLiteral.AddTodo.today
     @Published var formattedEndDate: String = StringLiteral.AddTodo.today
-
-    @Published var selectedTag: Tag = Tag.mockData.first(
-        where: { $0.tagId == 1 }
-    ) ?? Tag(tagId: 1, color: .gray05, title: "Untitled")
-    @Published var tagId: Int? = 1
-
-    @Published var priorityUrgency: Double? = 0.0
-    @Published var priorityImportance: Double? = 0.0
+    
+    private let tagService: TagAPIServiceProtocol
+    @Published var tags: [Tag] = []
+    
+    @Published var selectedTag: Tag = Tag(tagId: 1, color: .gray05, title: "Untitled") {
+        didSet {
+            tagId = selectedTag.tagId
+        }
+    }
+    @Published var tagId: Int = 1
+    
+    @Published var priorityUrgency: Double = 0.0
+    @Published var priorityImportance: Double = 0.0
     @Published var selectedPriority: Priority = .none {
         didSet {
             let (urgency, importance) = selectedPriority.getPriorityValues()
@@ -49,26 +54,55 @@ final class AddTodoViewModel: ObservableObject, TagSelectable {
             priorityImportance = importance
         }
     }
-
+    
     var isTextEmpty: Bool {
         description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-
+    
     private let todoAPIService: TodoAPIServiceProtocol
-
+    
     // MARK: - Initializer
-
-    init(todoAPIService: TodoAPIServiceProtocol = TodoAPIService()) {
+    
+    init(todoAPIService: TodoAPIServiceProtocol = TodoAPIService(),
+         tagService: TagAPIServiceProtocol = TagAPIService()) {
         self.todoAPIService = todoAPIService
+        self.tagService = tagService
         updateFormattedDate()
+        getTagsAPI()
     }
-
+    
     // MARK: - Helpers
-
+    
+    func getTagsAPI() {
+        tagService.getTags { [weak self] result in
+            guard let self = self else { return }
+            
+            if case let .success(baseDTO) = result,
+               let tagList = baseDTO?.data {
+                
+                self.tags = tagList.map { tag in
+                    Tag(
+                        tagId: tag.id,
+                        color: Color(hex: tag.colorCode),
+                        title: tag.name
+                    )
+                }
+                
+                if let firstTag = self.tags.first {
+                    self.selectedTag = firstTag
+                    self.tagId = firstTag.tagId
+                }
+                
+            } else {
+                print("태그 불러오기 실패")
+            }
+        }
+    }
+    
     func createTodo(completion: @escaping () -> Void) {
         let formattedStartDate = startDate.formattedDate(with: "yyyy-MM-dd")
         let formattedEndDate = endDate.formattedDate(with: "yyyy-MM-dd")
-
+        
         todoAPIService.createTodo(
             startDate: formattedStartDate,
             description: description,
@@ -96,20 +130,20 @@ final class AddTodoViewModel: ObservableObject, TagSelectable {
             }
         }
     }
-
+    
     func limitTextLength(_ newText: String) {
         let lines = newText.split(whereSeparator: \.isNewline)
-
+        
         if let lastLine = lines.last, lastLine.count > 30 {
             let truncated = String(lastLine.prefix(30))
             description = lines.dropLast()
-                        .map(String.init)
-                        .joined(separator: "\n") + "\n" + truncated + "\n"
+                .map(String.init)
+                .joined(separator: "\n") + "\n" + truncated + "\n"
         } else {
             description = newText
         }
     }
-
+    
     func getPriorityImage(_ priority: Priority) -> MDSImageName {
         switch priority {
         case .immediate: return .matrix_immediate
@@ -119,27 +153,27 @@ final class AddTodoViewModel: ObservableObject, TagSelectable {
         case .none: return .matrix_none
         }
     }
-
+    
     func postMakeScheduleNotiFication() {
         NotificationCenter.default.post(
             name: NSNotification.Name("postScheduleComplete"),
             object: nil
         )
     }
-
+    
     private func updateFormattedDate() {
         formattedStartDate = formattedStartDate(for: startDate)
         formattedEndDate = formattedEndDate(for: endDate)
     }
-
+    
     private func formattedStartDate(for date: Date) -> String {
         return Calendar.current.isDateInToday(date) ? StringLiteral.AddTodo.today : date.formattedDate(with: "MMM d, yyyy")
     }
-
+    
     private func formattedEndDate(for date: Date) -> String {
         return Calendar.current.isDateInToday(date) ? StringLiteral.AddTodo.today : date.formattedDate(with: "MMM d")
     }
-
+    
     private func getPriorityValues() -> (Double, Double) {
         return selectedPriority.getPriorityValues()
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/SegmentedMenuView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/SegmentedMenuView.swift
@@ -10,26 +10,26 @@ import SwiftUI
 import MDSKit
 
 struct SegmentedMenuView: View {
-
+    
     // MARK: - Properties
-
+    
     @ObservedObject private var viewModel: SegmentedMenuViewModel
     @Binding var sheetHeight: CGFloat
-
+    
     // MARK: - Initializer
-
+    
     init(viewModel: SegmentedMenuViewModel, sheetHeight: Binding<CGFloat>) {
         self.viewModel = viewModel
         self._sheetHeight = sheetHeight
     }
-
+    
     // MARK: - Body
-
+    
     var body: some View {
         GeometryReader { geometry in
             let screenHeight = geometry.size.height
             let calculatedSheetHeight = screenHeight * 0.8
-
+            
             VStack {
                 Spacer()
                 VStack {
@@ -51,9 +51,9 @@ struct SegmentedMenuView: View {
 // MARK: - UI Components
 
 private extension SegmentedMenuView {
-
+    
     // MARK: Menu Buttons
-
+    
     var menuButtonsView: some View {
         HStack {
             ForEach(SegmentedMenuType.allCases, id: \.self) { type in
@@ -68,7 +68,7 @@ private extension SegmentedMenuView {
         .padding(.top, 20)
         .padding(.bottom, 10)
     }
-
+    
     @ViewBuilder
     func configureMenuButton(type: SegmentedMenuType) -> some View {
         Button {
@@ -79,7 +79,7 @@ private extension SegmentedMenuView {
                     Circle()
                         .fill(viewModel.selectedButton == type ? Color.grayBlack : Color.clear)
                 }
-
+                
                 Image(type.image)
                     .renderingMode(.template)
                     .foregroundColor(viewModel.selectedButton == type ? .grayWhite : .gray07)
@@ -87,13 +87,16 @@ private extension SegmentedMenuView {
             .frame(width: 38, height: 38)
         }
     }
-
+    
     // MARK: Content View
-
+    
     @ViewBuilder
     var contentView: some View {
         switch viewModel.selectedButton {
-        case .checkbox: AddTodoView()
+        case .checkbox:
+            AddTodoView(onClose: {
+                viewModel.isPresented = false
+            })
         case .event: AddScheduleView()
         }
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/TagPickerSheet.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/TagPickerSheet.swift
@@ -9,20 +9,21 @@ import SwiftUI
 
 protocol TagSelectable: ObservableObject {
     var selectedTag: Tag { get set }
+    var showTagPicker: Bool { get set }
 }
 
 struct TagPickerSheet<ViewModel: TagSelectable>: View {
-
+    
     @ObservedObject var viewModel: ViewModel
-    @Binding var isPresented: Bool
-
+    //    @Binding var isPresented: Bool
+    
     let type: PickerButtonType
     let tagList: [Tag]
-
+    
     var body: some View {
         SheetContainer(type: type) {
-            SheetOKButton { isPresented = false }
-
+            SheetOKButton { viewModel.showTagPicker = false }
+            
             List {
                 ForEach(tagList) { tag in
                     Button(action: {
@@ -32,11 +33,11 @@ struct TagPickerSheet<ViewModel: TagSelectable>: View {
                             Circle()
                                 .fill(tag.color)
                                 .frame(width: 12, height: 12)
-
+                            
                             Text(tag.title)
                                 .applyFont(.body_r_14)
                                 .foregroundStyle(viewModel.selectedTag.id == tag.id ? Color.gray02 : Color.gray07)
-
+                            
                             Spacer()
                         }
                     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AuthViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/AuthViewModel.swift
@@ -7,10 +7,13 @@
 
 import SwiftUI
 import Combine
+
 import AuthenticationServices
 import Firebase
 import FirebaseAuth
 import GoogleSignIn
+
+import FirebaseMessaging
 
 enum AuthAction {
     case googleLogin
@@ -24,9 +27,9 @@ class AuthViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
     @Published var isAuthenticated: Bool = false
-
+    
     let loginService = LoginAPIService()
-
+    
     func send(action: AuthAction) {
         switch action {
         case .googleLogin:
@@ -39,12 +42,12 @@ class AuthViewModel: ObservableObject {
             signInWithAppleCompletion(result)
         }
     }
-
+    
     func signInWithGoogle() {
         Task { @MainActor in
             guard !isLoading else { return }
             isLoading = true
-
+            
             if GIDSignIn.sharedInstance.hasPreviousSignIn() {
                 GIDSignIn.sharedInstance.restorePreviousSignIn { [weak self] user, error in
                     Task { @MainActor in
@@ -60,12 +63,12 @@ class AuthViewModel: ObservableObject {
                 
                 let configuration = GIDConfiguration(clientID: clientID)
                 GIDSignIn.sharedInstance.configuration = configuration
-
+                
                 guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController else {
                     handleError(nil, defaultMessage: "루트 뷰 컨트롤러를 찾을 수 없습니다.")
                     return
                 }
-
+                
                 GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController) { [weak self] result, error in
                     Task { @MainActor in
                         guard let self = self else { return }
@@ -79,7 +82,7 @@ class AuthViewModel: ObservableObject {
             }
         }
     }
-
+    
     func signOutWithGoogle() {
         GIDSignIn.sharedInstance.signOut()
         do {
@@ -89,18 +92,18 @@ class AuthViewModel: ObservableObject {
             print("Google 로그아웃 실패: \(error.localizedDescription)")
         }
     }
-
+    
     private func signInWithApple(_ request: ASAuthorizationAppleIDRequest) {
         request.requestedScopes = [.fullName, .email]
         request.requestedOperation = .operationLogin
     }
-
+    
     private func signInWithAppleCompletion(_ result: Result<ASAuthorization, Error>) {
         Task { @MainActor in
             guard !isLoading else { return }
             isLoading = true
             defer { isLoading = false }
-
+            
             switch result {
             case .success(let authorization):
                 await processAppleAuthorization(authorization)
@@ -109,7 +112,7 @@ class AuthViewModel: ObservableObject {
             }
         }
     }
-
+    
     private func handleError(_ error: Error?, defaultMessage: String) {
         self.errorMessage = error?.localizedDescription ?? defaultMessage
         self.isAuthenticated = false
@@ -120,6 +123,7 @@ class AuthViewModel: ObservableObject {
 //MARK: HTTP Memento 서버 통신 부분
 
 extension AuthViewModel {
+    
     private func authenticateUser(for user: GIDGoogleUser?, with error: Error?) async {
         defer { isLoading = false }
 
@@ -133,17 +137,30 @@ extension AuthViewModel {
             return
         }
 
-        loginService.login(provider: "GOOGLE", idToken: idToken) { [weak self] result in
-            guard let self = self else { return }
+        do {
+            let fcmToken = try await Messaging.messaging().token()
+            let timeZoneOffset = Self.currentTimeZoneOffset()
 
-            switch result {
-            case .success(let response):
-                self.handleLoginSuccess(response?.data)
-            case .unAuthorized:
-                self.handleError(nil, defaultMessage: "인증 실패. 다시 로그인하세요.")
-            default:
-                self.handleError(nil, defaultMessage: "서버 오류가 발생했습니다.")
+            loginService.login(
+                provider: "GOOGLE",
+                idToken: idToken,
+                timeZoneOffset: timeZoneOffset,
+                fcmToken: fcmToken
+            ) { [weak self] result in
+                guard let self = self else { return }
+
+                switch result {
+                case .success(let response):
+                    self.handleLoginSuccess(response?.data)
+                case .unAuthorized:
+                    self.handleError(nil, defaultMessage: "인증 실패. 다시 로그인하세요.")
+                default:
+                    self.handleError(nil, defaultMessage: "서버 오류가 발생했습니다.")
+                }
             }
+
+        } catch {
+            handleError(error, defaultMessage: "FCM 토큰을 가져올 수 없습니다.")
         }
     }
 
@@ -155,17 +172,30 @@ extension AuthViewModel {
             return
         }
 
-        loginService.login(provider: "APPLE", idToken: idTokenString) { [weak self] result in
-            guard let self = self else { return }
+        do {
+            let fcmToken = try await Messaging.messaging().token()
+            let timeZoneOffset = Self.currentTimeZoneOffset()
 
-            switch result {
-            case .success(let response):
-                self.handleLoginSuccess(response?.data)
-            case .unAuthorized:
-                self.handleError(nil, defaultMessage: "인증 실패. 다시 로그인하세요.")
-            default:
-                self.handleError(nil, defaultMessage: "서버 오류가 발생했습니다.")
+            loginService.login(
+                provider: "APPLE",
+                idToken: idTokenString,
+                timeZoneOffset: timeZoneOffset,
+                fcmToken: fcmToken
+            ) { [weak self] result in
+                guard let self = self else { return }
+
+                switch result {
+                case .success(let response):
+                    self.handleLoginSuccess(response?.data)
+                case .unAuthorized:
+                    self.handleError(nil, defaultMessage: "인증 실패. 다시 로그인하세요.")
+                default:
+                    self.handleError(nil, defaultMessage: "서버 오류가 발생했습니다.")
+                }
             }
+
+        } catch {
+            handleError(error, defaultMessage: "FCM 토큰을 가져올 수 없습니다.")
         }
     }
 
@@ -174,10 +204,26 @@ extension AuthViewModel {
         do {
             try TokenKeychainManager.shared.saveAccessToken(data.accessToken)
             try TokenKeychainManager.shared.saveRefreshToken(data.refreshToken)
+
+            AppState.shared.isLoggedIn = true
+
             self.isAuthenticated = true
             print("로그인 성공 및 토큰 저장 완료")
         } catch {
             handleError(error, defaultMessage: "토큰 저장 실패")
         }
     }
+
+
+}
+
+
+extension AuthViewModel {
+    private static func currentTimeZoneOffset() -> String {
+        let seconds = TimeZone.current.secondsFromGMT()
+        let hours = seconds / 3600
+        let minutes = abs(seconds / 60 % 60)
+        return String(format: "%+03d:%02d", hours, minutes)
+    }
+
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
ToDo 생성 버그 수정: 
- 생성 가능
- 생성하면 시트 닫히게 하기
- 생성하는 시트 올라올 때 schedule tab으로 간 다음에 올라오는 버그 수정

알림 권한 없이 FCM 토큰 받아서 서버에 저장

## 🚨 참고 사항
FCM과 APNs의 관계
Firebase Cloud Messaging (FCM) 은 Apple 기기에 직접 알림을 보내지 않는다.
FCM 서버는 APNs를 통해 iOS로 알림을 전달한다.

따라서 FCM이 iOS 기기로 알림을 보내려면
1. 앱에서 APNs 토큰 받아야 함
2. 그 토큰을 FCM SDK에 등록
3. FCM 서버가 APNs로 푸시 전달

즉, FCM 토큰 = FCM 서버용 식별자
APNs 토큰 = 실제 iOS 기기용 식별자

둘이 매핑되어야 알림이 도착할 수 있다.


## 🖥️ 주요 코드 설명
### Before (mcrkgus의 핫픽스)

UNUserNotificationCenter.current().requestAuthorization(...)가 활성화
FCM 토큰을 발급하려면 APNs 토큰이 필요한데
알아보니까 APNs 토큰은 사용자가 알림 권한을 허용했을 때 발급된다고 하네요 (아닐 수도 있음, 참고 사항 참고 바람)

결론적으로 로그인 시점에 FCM 토큰을 서버로 전달해야 하는데 (없으면 당연히 로그인 실패 / 서버 요청 오류 발생)
**알림 권한 없이**도 FCM 토큰을 받을 수 있어야 했습니다
```swift
...
UNUserNotificationCenter.current().delegate = self
UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
    if let error = error {
        print("알림 권한 요청 실패: \(error.localizedDescription)")
        return
    }
    if granted {
        DispatchQueue.main.async {
            UIApplication.shared.registerForRemoteNotifications()
        }
    } else {
        print("알림 권한 거부")
    }
}
...
```


### After (sem-git의 핫픽스)
우선 사용자가 알림 거부해도 로그인 가능해야 하니까 관련 코드를 주석 처리했구요
더미 APNs 토큰을 세팅했습니다 (이게 과연 맞는 방법인지는 모르겠는데)
```swift
Messaging.messaging().apnsToken = Data(repeating: 0, count: 32)
```

따라서 iOS는 APNs 토큰이 있다고 판단하여 FCM 토큰을 발급합니다
실제 APNs와 연결되진 않지만 로그인 시점에는 서버에 FCM 토큰이 전달돼서 알림 권한 없이도 로그인 가능합니다
(나중에 사용자가 권한 허용하면 FCM SDK가 실제 APNs 토큰과 매핑되도록 해야 할 것 같은데..)


**결론 : FCM 토큰 발급을 위해 APNs 토큰 필요 → 로그인용 최소 요구를 채우기 위해 더미 APNs 세팅해서 FCM 토큰 발급 → 로그인 시 서버 요청 가능**

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #26 
