### PR TITLE
[Feat] #12 - FCM 토큰 갱신 및 최적화, 로그아웃, 탈퇴 구현 

### DIFF
--- a/Memento-iOS/Memento-iOS/Info.plist
+++ b/Memento-iOS/Memento-iOS/Info.plist
@@ -27,5 +27,7 @@
 		<key>UIImageName</key>
 		<string>img_splash_logo</string>
 	</dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -85,7 +85,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 print("FCM 토큰 저장 완료 & 서버 동기화 필요")
                 
                 // 서버에 최신 FCM 토큰 전송
-                // MyAPIService.shared.updateFCMToken(token)
             }
             
         } catch {
@@ -95,7 +94,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 print("📌 FCM 토큰 신규 저장 완료 & 서버 동기화 필요")
                 
                 // 서버에 최신 FCM 토큰 전송
-                // MyAPIService.shared.updateFCMToken(token)
             } catch {
                 print("❌ FCM 토큰 저장 실패: \(error)")
             }
@@ -138,9 +136,9 @@ struct MementoApp: App {
                 .task {
                     authSession.autoLoginOnLaunch()
                 }
-                //.onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함
-                //    Task { await authSession.withdraw() }
-                //}
+            //.onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함
+            //    Task { await authSession.withdraw() }
+            //}
         }
     }
     

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -104,16 +104,12 @@ struct MementoApp: App {
     @StateObject private var authSession = AuthSession.shared
     @StateObject private var onboardingViewModel = OnboardingViewModel()
     @State var showLottieAnimation: Bool = true
-    @State private var didRunAutoLoginOnce = false
-    
     
     var body: some Scene {
         WindowGroup {
             rootView
                 .environmentObject(authSession) // 앱 전체에서 사용자 세션 감시 (사용 가능하게)
-                .onAppear {
-                    guard !didRunAutoLoginOnce else { return }
-                    didRunAutoLoginOnce = true
+                .task {
                     authSession.autoLoginOnLaunch()
                 }
             //                .onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -16,46 +16,106 @@ import FirebaseMessaging
 import UserNotifications
 import FirebaseAuth
 
-class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
     
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         
-        registerFonts()
+        // Firebase 초기화
         FirebaseApp.configure()
-        Messaging.messaging().isAutoInitEnabled = true
-        Messaging.messaging().apnsToken = Data(repeating: 0, count: 32)
+        
+        // FCM 메시징 델리게이트 지정
+        Messaging.messaging().delegate = self
+        
+        // 알림 센터 델리게이트 지정
         UNUserNotificationCenter.current().delegate = self
         
-        //        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-        //            if let error = error {
-        //                print("알림 권한 요청 실패: \(error.localizedDescription)")
-        //                return
-        //            }
-        //            if granted {
-        //                DispatchQueue.main.async {
-        //                    UIApplication.shared.registerForRemoteNotifications()
-        //                }
-        //            } else {
-        //                print("알림 권한 거부")
-        //            }
-        //        }
+        // 실행 시마다 권한 상태 점검 & 요청
+        checkAndRequestPushPermission()
         
-        Thread.sleep(forTimeInterval: 2)
+        
         return true
     }
     
+    // MARK: - 권한 제어 테스트 메서드
+    
+     private func checkAndRequestPushPermission() {
+         UNUserNotificationCenter.current().getNotificationSettings { settings in
+             switch settings.authorizationStatus {
+                 
+             case .notDetermined:
+                 // 아직 권한 요청을 안 한 경우 → 권한 요청
+                 UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+                     if let error = error {
+                         print("알림 권한 요청 실패: \(error.localizedDescription)")
+                         return
+                     }
+                     if granted {
+                         DispatchQueue.main.async {
+                             UIApplication.shared.registerForRemoteNotifications()
+                         }
+                         print("알림 권한 허용")
+                     } else {
+                         print("알림 권한 거부 (처음 요청)")
+                     }
+                 }
+                 
+             case .denied:
+                 // 이미 거부됨 → 설정 화면으로 유도
+                 print("알림 권한 거부 상태 → 설정 앱으로 이동 필요")
+                 DispatchQueue.main.async {
+                     if let appSettings = URL(string: UIApplication.openSettingsURLString) {
+                         UIApplication.shared.open(appSettings)
+                     }
+                 }
+                 
+             case .authorized, .provisional, .ephemeral:
+                 // 이미 허용된 상태 → 바로 APNs 등록
+                 DispatchQueue.main.async {
+                     UIApplication.shared.registerForRemoteNotifications()
+                 }
+                 print("이미 알림 권한 있음")
+                 
+             @unknown default:
+                 break
+             }
+         }
+     }
+    
+    // APNs 등록 성공
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         print("APNs 디바이스 토큰 등록 성공")
         Messaging.messaging().apnsToken = deviceToken
     }
     
+    // APNs 등록 실패
     func application(_ application: UIApplication,
                      didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("APNs 디바이스 토큰 등록 실패: \(error.localizedDescription)")
     }
     
+    // FCM 토큰 수신 (최신 방식)
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let token = fcmToken else { return }
+        print("📌 Firebase FCM 등록 토큰: \(token)")
+        
+        // 👉 서버에 전송 or UserDefaults 저장
+        // MyAPIService.shared.updateFCMToken(token)
+    }
+    
+    // 필요시 직접 가져오기
+    func fetchFCMTokenManually() {
+        Messaging.messaging().token { token, error in
+            if let error = error {
+                print("❌ FCM 토큰 가져오기 실패: \(error.localizedDescription)")
+            } else if let token = token {
+                print("📌 수동으로 가져온 FCM 토큰: \(token)")
+            }
+        }
+    }
+    
+    // 외부 앱 (예: 구글 로그인) 콜백 처리
     func application(_ app: UIApplication,
                      open url: URL,
                      options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -80,11 +140,11 @@ struct MementoApp: App {
                 .onAppear {
                     guard !didRunAutoLoginOnce else { return }
                     didRunAutoLoginOnce = true
-                    authSession.autoLoginOnLaunch() 
+                    authSession.autoLoginOnLaunch()
                 }
-//                .onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함
-//                    Task { await withdrawAndSignOut() }
-//                }
+            //                .onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함
+            //                    Task { await withdrawAndSignOut() }
+            //                }
         }
     }
     

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -32,7 +32,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         // 알림 센터 델리게이트 지정
         UNUserNotificationCenter.current().delegate = self
         
-        // 🚀 권한 여부와 무관하게 항상 APNs 등록 요청
+        // 권한 여부와 무관하게 항상 APNs 등록 요청
         UIApplication.shared.registerForRemoteNotifications()
         
         // 권한 요청 팝업 요청
@@ -48,6 +48,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     }
     
     // MARK: - APNs 등록 성공
+    
     func application(
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
@@ -60,6 +61,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     }
     
     // MARK: - APNs 등록 실패
+    
     func application(
         _ application: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: Error
@@ -68,12 +70,36 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     }
     
     // MARK: - FCM 토큰 수신 (최신 방식)
+    
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let token = fcmToken else { return }
-        print("📌 Firebase FCM 등록 토큰: \(token)")
+        print("📌 Firebase FCM 등록 토큰 수신: \(token)")
         
-        // 서버 전송 or 로컬 저장
-        // MyAPIService.shared.updateFCMToken(token)
+        do {
+            let cached = try TokenKeychainManager.shared.getFCMToken()
+            
+            if cached == token {
+                print("기존 FCM 토큰과 동일 → 서버 전송 생략")
+            } else {
+                try TokenKeychainManager.shared.saveFCMToken(token)
+                print("FCM 토큰 저장 완료 & 서버 동기화 필요")
+                
+                // 서버에 최신 FCM 토큰 전송
+                // MyAPIService.shared.updateFCMToken(token)
+            }
+            
+        } catch {
+            // Keychain 조회 실패 → 그냥 새 값 저장
+            do {
+                try TokenKeychainManager.shared.saveFCMToken(token)
+                print("📌 FCM 토큰 신규 저장 완료 & 서버 동기화 필요")
+                
+                // 서버에 최신 FCM 토큰 전송
+                // MyAPIService.shared.updateFCMToken(token)
+            } catch {
+                print("❌ FCM 토큰 저장 실패: \(error)")
+            }
+        }
     }
     
     // 필요시 직접 가져오기

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -18,8 +18,10 @@ import FirebaseAuth
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
     
-    func application(_ application: UIApplication,
-                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
         
         // Firebase 초기화
         FirebaseApp.configure()
@@ -30,77 +32,47 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         // 알림 센터 델리게이트 지정
         UNUserNotificationCenter.current().delegate = self
         
-        // 실행 시마다 권한 상태 점검 & 요청
-        checkAndRequestPushPermission()
+        // 🚀 권한 여부와 무관하게 항상 APNs 등록 요청
+        UIApplication.shared.registerForRemoteNotifications()
         
+        // 권한 요청 팝업 요청
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("알림 권한 요청 실패: \(error.localizedDescription)")
+                return
+            }
+            print("알림 권한 상태: \(granted ? "허용 ✅" : "거부 ❌")")
+        }
         
         return true
     }
     
-    // MARK: - 권한 제어 테스트 메서드
-    
-     private func checkAndRequestPushPermission() {
-         UNUserNotificationCenter.current().getNotificationSettings { settings in
-             switch settings.authorizationStatus {
-                 
-             case .notDetermined:
-                 // 아직 권한 요청을 안 한 경우 → 권한 요청
-                 UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-                     if let error = error {
-                         print("알림 권한 요청 실패: \(error.localizedDescription)")
-                         return
-                     }
-                     if granted {
-                         DispatchQueue.main.async {
-                             UIApplication.shared.registerForRemoteNotifications()
-                         }
-                         print("알림 권한 허용")
-                     } else {
-                         print("알림 권한 거부 (처음 요청)")
-                     }
-                 }
-                 
-             case .denied:
-                 // 이미 거부됨 → 설정 화면으로 유도
-                 print("알림 권한 거부 상태 → 설정 앱으로 이동 필요")
-                 DispatchQueue.main.async {
-                     if let appSettings = URL(string: UIApplication.openSettingsURLString) {
-                         UIApplication.shared.open(appSettings)
-                     }
-                 }
-                 
-             case .authorized, .provisional, .ephemeral:
-                 // 이미 허용된 상태 → 바로 APNs 등록
-                 DispatchQueue.main.async {
-                     UIApplication.shared.registerForRemoteNotifications()
-                 }
-                 print("이미 알림 권한 있음")
-                 
-             @unknown default:
-                 break
-             }
-         }
-     }
-    
-    // APNs 등록 성공
-    func application(_ application: UIApplication,
-                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        print("APNs 디바이스 토큰 등록 성공")
+    // MARK: - APNs 등록 성공
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        print("📌 APNs 디바이스 토큰 등록 성공: \(tokenString)")
+        
+        // FCM에 연결
         Messaging.messaging().apnsToken = deviceToken
     }
     
-    // APNs 등록 실패
-    func application(_ application: UIApplication,
-                     didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("APNs 디바이스 토큰 등록 실패: \(error.localizedDescription)")
+    // MARK: - APNs 등록 실패
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        print("⚠️ APNs 디바이스 토큰 등록 실패: \(error.localizedDescription)")
     }
     
-    // FCM 토큰 수신 (최신 방식)
+    // MARK: - FCM 토큰 수신 (최신 방식)
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let token = fcmToken else { return }
         print("📌 Firebase FCM 등록 토큰: \(token)")
         
-        // 👉 서버에 전송 or UserDefaults 저장
+        // 서버 전송 or 로컬 저장
         // MyAPIService.shared.updateFCMToken(token)
     }
     
@@ -115,10 +87,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         }
     }
     
-    // 외부 앱 (예: 구글 로그인) 콜백 처리
-    func application(_ app: UIApplication,
-                     open url: URL,
-                     options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    // MARK: - 외부 앱 콜백 처리 (예: 구글 로그인)
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
         return GIDSignIn.sharedInstance.handle(url)
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
+++ b/Memento-iOS/Memento-iOS/Source/App/Memento_iOSApp.swift
@@ -138,9 +138,9 @@ struct MementoApp: App {
                 .task {
                     authSession.autoLoginOnLaunch()
                 }
-            //                .onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함
-            //                    Task { await withdrawAndSignOut() }
-            //                }
+                //.onAppear { // 탈퇴시 로그인 된 탭 화면에서 해당 코드 실행 해야함
+                //    Task { await authSession.withdraw() }
+                //}
         }
     }
     
@@ -157,37 +157,6 @@ struct MementoApp: App {
                 LoginView()
                     .environmentObject(onboardingViewModel)
                     .preferredColorScheme(.dark)
-            }
-        }
-    }
-    
-    /// 회원 탈퇴 + 세션/토큰 정리
-    private func withdrawAndSignOut() async {
-        // (선택) 토큰 없으면 바로 종료
-        if (try? TokenKeychainManager.shared.getAccessToken()) == nil {
-            print("⚠️ AccessToken 없음: 탈퇴 API 호출 생략")
-            return
-        }
-        
-        let service = MemberAPIService() // DELETE /api/v1/members 호출하는 서비스
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            service.withdraw { result in
-                switch result {
-                case .success:
-                    // 토큰/세션 정리
-                    print("✅ 회원 탈퇴 완료")
-                    try? TokenKeychainManager.shared.clearTokens()
-                    GIDSignIn.sharedInstance.signOut()
-                    try? Auth.auth().signOut()
-                    Task { @MainActor in
-                        authSession.isLoggedIn = false
-                    }
-                case .unAuthorized:
-                    print("⚠️ 401 Unauthorized: 토큰 만료/로그인 필요")
-                default:
-                    print("❌ 회원 탈퇴 실패(서버 오류)")
-                }
-                cont.resume()
             }
         }
     }

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Network.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Network.swift
@@ -14,16 +14,33 @@ extension AuthSession {
     
     /// 서버 로그인 공통 메서드
     /// 첫 로그인 토큰 저장 로직 여기에 위치함
-     func requestLogin(provider: String, idToken: String) async {
+    func requestLogin(provider: String, idToken: String) async {
         do {
-            let fcmToken = try await Messaging.messaging().token()
+            // 1. Keychain에 저장된 FCM 토큰 확인
+            let cachedToken = try? keychain.getFCMToken()
+              
+              // 2. Firebase에서 최신 토큰 가져오기
+              let newToken = try await Messaging.messaging().token()
+              
+              // 3. 캐시와 비교 후 필요한 경우만 서버 전송
+              let fcmTokenToSend: String
+              if cachedToken == newToken {
+                  print("📌 기존 FCM 토큰과 동일 → 캐시 사용")
+                  fcmTokenToSend = cachedToken ?? newToken
+              } else {
+                  print("📌 새로운 FCM 토큰 감지 → 저장 & 전송")
+                  try? keychain.saveFCMToken(newToken)
+                  fcmTokenToSend = newToken
+              }
+            
             let timeZoneOffset = Self.currentTimeZoneOffset()
-
+            
+            
             memberService.socialLogin(
                 provider: provider,
                 idToken: idToken,
                 timeZoneOffset: timeZoneOffset,
-                fcmToken: fcmToken
+                fcmToken: fcmTokenToSend
             ) { [weak self] result in
                 Task { @MainActor in
                     guard let self else { return }
@@ -34,9 +51,10 @@ extension AuthSession {
                             self.isLoading = false
                             return
                         }
-
+                        
                         self.setTokens(accessToken: data.accessToken, refreshToken: data.refreshToken)
-
+                        
+                        /// 온보딩 전환유무는  여기에서만 처리
                         if data.isNewUser {
                             self.shouldStartOnboarding = true
                             self.isLoggedIn = false
@@ -45,11 +63,11 @@ extension AuthSession {
                             self.isLoggedIn = true
                         }
                         self.isLoading = false
-
+                        
                     case .unAuthorized:
                         self.errorMessage = "인증 실패. 다시 로그인하세요."
                         self.isLoading = false
-
+                        
                     default:
                         self.errorMessage = "서버 오류가 발생했습니다."
                         self.isLoading = false

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
@@ -98,7 +98,37 @@ final class AuthSession: ObservableObject {
             }
         }
     }
-
     
-    // MARK: - 추후 로그아웃, 탈퇴 로직 여기에 위치
+    // MARK: - 로그아웃
+    func logout() {
+        print("로그아웃 실행: 세션/토큰 정리")
+        clear()
+        GIDSignIn.sharedInstance.signOut()
+        try? Auth.auth().signOut()
+    }
+    
+    // MARK: - 회원 탈퇴
+    func withdraw() async {
+        guard let _ = try? keychain.getAccessToken() else {
+            print("⚠️ AccessToken 없음 → 탈퇴 API 호출 생략")
+            clear()
+            return
+        }
+        
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            memberService.withdraw { result in
+                switch result {
+                case .success:
+                    print("회원 탈퇴 성공")
+                    self.logout() // 로그아웃과 동일하게 세션 정리
+                case .unAuthorized:
+                    print("401 Unauthorized: 이미 만료된 토큰")
+                    self.clear()
+                default:
+                    print("회원 탈퇴 실패(서버 오류)")
+                }
+                cont.resume()
+            }
+        }
+    }
 }

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
@@ -18,22 +18,22 @@ import GoogleSignIn
 @MainActor
 final class AuthSession: ObservableObject {
     static let shared = AuthSession()
-
+    
     // MARK: - Session State
     
     @Published var isLoggedIn: Bool = false
     @Published var isLoading: Bool = false
     @Published var shouldStartOnboarding: Bool = false
     @Published var errorMessage: String?
-
+    
     // MARK: - Dependencies
     
     let keychain = TokenKeychainManager.shared
     let memberService = MemberAPIService()
     var hasValidAccessToken: Bool {
-          keychain.hasValidToken()
-      }
-
+        keychain.hasValidToken()
+    }
+    
     private init() {
         isLoggedIn = keychain.hasValidToken()
     }
@@ -49,7 +49,7 @@ final class AuthSession: ObservableObject {
         errorMessage = nil
         isLoading = false
     }
-
+    
     // MARK: - Error/Helper
     
     func handleError(_ error: Error?, defaultMessage: String) {
@@ -62,18 +62,43 @@ final class AuthSession: ObservableObject {
     // MARK: - 자동 로그인
     
     func autoLoginOnLaunch() {
-        // Access 토큰이 있고 아직 만료 전이면 로그인 상태로만 세팅
-        if let token = try? keychain.getAccessToken(),
-            !token.isEmpty,
-           !keychain.isTokenExpired(token) {
+        // 1. AccessToken이 유효 → 바로 로그인 유지
+        if let access = try? TokenKeychainManager.shared.getAccessToken(),
+           !access.isEmpty,
+           !TokenKeychainManager.shared.isTokenExpired(access) {
+            print("AccessToken 유효 → 로그인 유지")
             isLoggedIn = true
-            shouldStartOnboarding = false
-        } else {
-            // 만료/부재 → 로그인 화면. 실제 호출 시 401이면 인터셉터가 갱신 시도
-            isLoggedIn = false
-            shouldStartOnboarding = false
+            return
+        }
+        
+        // 2. AccessToken이 없거나 만료 → Refresh 시도
+        RefreshService.refreshTokens { result in
+            switch result {
+            case .success(let tokenData):
+                do {
+                    try TokenKeychainManager.shared.saveAccessToken(tokenData.accessToken)
+                    try TokenKeychainManager.shared.saveRefreshToken(tokenData.refreshToken)
+                    print("AccessToken만료 -> Refresh 성공 → 새 토큰 저장")
+                    
+                    DispatchQueue.main.async {
+                        self.isLoggedIn = true
+                    }
+                } catch {
+                    print("❌ 새 토큰 저장 실패: \(error.localizedDescription)")
+                    DispatchQueue.main.async {
+                        self.isLoggedIn = false
+                    }
+                }
+                
+            case .failure(let error):
+                print("❌ Refresh 실패: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.isLoggedIn = false
+                }
+            }
         }
     }
+
     
     // MARK: - 추후 로그아웃, 탈퇴 로직 여기에 위치
 }

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
@@ -122,7 +122,6 @@ final class AuthSession: ObservableObject {
                     print("회원 탈퇴 성공")
                     self.logout() // 로그아웃과 동일하게 세션 정리
                 case .unAuthorized:
-                    print("401 Unauthorized: 이미 만료된 토큰")
                     self.clear()
                 default:
                     print("회원 탈퇴 실패(서버 오류)")

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/Token/TokenInterceptor.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/Token/TokenInterceptor.swift
@@ -160,6 +160,7 @@ final class TokenInterceptor: RequestInterceptor {
         return path == refreshPath
     }
 
+    // 리프래시 토큰 만료시 모든 토큰을 지우고 강제 로그인
     private func forceRelogin() {
         try? TokenKeychainManager.shared.clearTokens()
         DispatchQueue.main.async {

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/Token/TokenKeychainManager.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/Token/TokenKeychainManager.swift
@@ -70,6 +70,21 @@ final class TokenKeychainManager {
         return value
     }
     
+    // MARK: - 삭제 메서드
+    
+    func delete(key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw KeychainError.unhandledError(status)
+        }
+    }
+    
+    
     // MARK: - Access Token 저장, 가져오기
     
     func saveAccessToken(_ token: String) throws {
@@ -97,19 +112,9 @@ final class TokenKeychainManager {
     func clearTokens() throws {
         try delete(key: "AccessToken")
         try delete(key: "RefreshToken")
+        try delete(key: "FCMToken")
     }
     
-    func delete(key: String) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key
-        ]
-        
-        let status = SecItemDelete(query as CFDictionary)
-        if status != errSecSuccess && status != errSecItemNotFound {
-            throw KeychainError.unhandledError(status)
-        }
-    }
     
     // MARK: - Token 유효성 검사 (만료시각 확인)
     /// 키체인에서 액세스 토큰을 꺼내서 비어있지 않고, 만료되지 않았는지 확인
@@ -123,6 +128,21 @@ final class TokenKeychainManager {
         } catch {
             return false
         }
+    }
+    
+    // MARK: - FCM Token 저장 / 가져오기
+    
+    func saveFCMToken(_ token: String) throws {
+        print("FCM Token 저장 완료")
+        try save(key: "FCMToken", value: token)
+    }
+    
+    func getFCMToken() throws -> String? {
+        return try load(key: "FCMToken")
+    }
+    
+    func deleteFCMToken() throws {
+        try delete(key: "FCMToken")
     }
 
     func isTokenExpired(_ token: String) -> Bool {

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -170,11 +170,6 @@ extension OnboardingViewModel {
                     // 온보딩 네비 스택 정리
                     self.resetNavigation()
                     
-                case .unAuthorized:
-                    // 세션 만료 등 → 로그인 화면으로
-                    self.errorMessage = "세션이 만료되었습니다. 다시 로그인 해주세요."
-                    AuthSession.shared.clear()
-                    
                 default:
                     self.errorMessage = "회원 개인 정보 업데이트 실패"
                 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
@@ -156,12 +156,18 @@ struct SettingView: View {
     }
     
     struct AccountSettingsSection: View {
+        @EnvironmentObject var authSession: AuthSession
+        
         var body: some View {
             VStack {
                 HStack {
-                    Text(SettingsSettingViewText.logout)
-                        .applyFont(.body_r_14)
-                        .foregroundColor(Color.mementoRed)
+                    Button {
+                        authSession.logout()
+                    } label: {
+                        Text(SettingsSettingViewText.logout)
+                            .applyFont(.body_r_14)
+                            .foregroundColor(Color.mementoRed)
+                    }
                     
                     Spacer()
                 }
@@ -169,10 +175,15 @@ struct SettingView: View {
                 .padding(.horizontal, 26)
                 
                 HStack {
-                    Text(SettingsSettingViewText.deleteAccount)
-                        .applyFont(.body_r_14)
-                        .foregroundColor(Color.mementoRed)
-                    
+                    Button {
+                        Task {
+                            await authSession.withdraw()
+                        }
+                    } label: {
+                        Text(SettingsSettingViewText.deleteAccount)
+                            .applyFont(.body_r_14)
+                            .foregroundColor(Color.mementoRed)
+                    }
                     Spacer()
                 }
                 .padding(.top, 15)


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- **자동 로그인 에러 해결**
    - 앱 진입점에서 토큰 만료 체크(엑세스, 리프레시)
    
- **알림 권한과 무관한 FCM 토큰 발급**
    - `UIApplication.shared.registerForRemoteNotifications()`를 앱 실행 시 항상 호출
    - → 사용자 알림 권한 거부 상태라도 **실제 유효한 APNs/FCM 토큰이 발급**되도록 보장
    - 서버는 권한 허용/거부 여부와 상관없이 항상 올바른 토큰을 관리 가능
   
- **FCM 토큰 관리 최적화**
    - `AppDelegate.messaging(_:didReceiveRegistrationToken:)` 에서 FCM 토큰 수신 시 Keychain과 비교 후 **변경된 경우에만 저장 및 서버 전송**
    - `AuthSession.requestLogin()` 에서 Keychain 캐시 값과 Firebase 최신값 비교 후 동기화
    
- **로그아웃 기능 추가**
    - `AuthSession.logout()` 메서드 구현
    - 세션/토큰 정리 및 Google/Firebase 로그아웃 처리
    
- **회원 탈퇴 기능 추가**
    - `AuthSession.withdraw()` 메서드 구현
    - 서버 탈퇴 API 호출 후 세션/토큰 정리

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
didReceiveRegistrationToken 은 FCM 토큰이 갱신되지 않아도 항상 호출될 수 있는 콜백입니다.
→ 따라서 Keychain 비교 후 달라졌을 때만 저장/전송하도록 최적화했습니다.
but 서버 API가 나오지 않아 미리 설계만 해두었고 나오면 바로 연결할 수 있게 했습니다.

UIApplication.shared.registerForRemoteNotifications() 사용하면 알림 권한 허용 여부와 무관하게 FCM 토큰 발급이 가능하므로
서버에는 항상 유효한 토큰이 저장됨
권한 허용 유저 → 푸시 알림 표시
권한 거부 유저 → 푸시는 기기까지 도달하지만 표시되지 않음
운영/분석 시 “도달률 저하 = 권한 거부”로 정확히 구분 가능

### 목업(Mock) 토큰을 넣었을 때 문제점

1. **잘못된 FCM 토큰 생성**
    - Firebase는 내부적으로 APNs 토큰을 기반으로 FCM 토큰을 발급하는데, 목업값(예: `0000...`)을 넣으면 실제 기기와 매핑되지 않는 가짜 토큰이 만들어짐.
2. **서버 부하 & 오류 로그 증가**
    - 서버는 “겉보기에 정상 토큰”을 받아서 전송 시도 → APNs/FCM 단에서 매번 실패
    - 불필요한 재시도로 서버 부하 및 실패 로그 폭발
3. **QA/운영 혼란**
    - 콘솔에 `"FCM 등록 토큰: …"` 로그가 찍히니 정상처럼 보여서 디버깅 시간 낭비
4. **통계 왜곡**
    - 실제로는 권한 거부 유저인데, 목업 토큰 때문에 “푸시 전송했는데 실패율이 높다”로 오해 가능
    - 운영/분석 데이터 신뢰도 하락
  

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/1ca81445-d55c-4138-ac4c-e4146bcc3864" width ="250"> | <img src = "https://github.com/user-attachments/assets/1ca81445-d55c-4138-ac4c-e4146bcc3864" width ="250"> | <img src = "https://github.com/user-attachments/assets/1ca81445-d55c-4138-ac4c-e4146bcc3864" width ="250"> |


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`Memento_iOSApp`
Messaging.messaging().apnsToken = deviceToken 라인 실행시
Firebase SDK(FirebaseMessaging)가 이 APNs 토큰을 Firebase 서버에 등록합니다.
Firebase 서버는 이 APNs 토큰을 기반으로 FCM Registration Token을 발급합니다.
→ 이 값이 messaging(_:didReceiveRegistrationToken:) 콜백으로 전달되고,
→ Messaging.messaging().token() 으로도 가져올 수 있게 됩니다.

```swift
class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
    
    func application(
        _ application: UIApplication,
        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
    ) -> Bool {
        
        // Firebase 초기화
        FirebaseApp.configure()
        
        // FCM 메시징 델리게이트 지정
        Messaging.messaging().delegate = self
        
        // 알림 센터 델리게이트 지정
        UNUserNotificationCenter.current().delegate = self
        
        // 권한 여부와 무관하게 항상 APNs 등록 요청
        UIApplication.shared.registerForRemoteNotifications()
        
        // 권한 요청 팝업 요청
        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
            if let error = error {
                print("알림 권한 요청 실패: \(error.localizedDescription)")
                return
            }
            print("알림 권한 상태: \(granted ? "허용 ✅" : "거부 ❌")")
        }
        
        return true
    }
    
    // MARK: - APNs 등록 성공
    
    func application(
        _ application: UIApplication,
        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
    ) {
        let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
        print("📌 APNs 디바이스 토큰 등록 성공: \(tokenString)")
        
        // FCM에 연결
        Messaging.messaging().apnsToken = deviceToken
    }
    
    // MARK: - APNs 등록 실패
    
    func application(
        _ application: UIApplication,
        didFailToRegisterForRemoteNotificationsWithError error: Error
    ) {
        print("⚠️ APNs 디바이스 토큰 등록 실패: \(error.localizedDescription)")
    }
    
    // MARK: - FCM 토큰 수신 (최신 방식)
    
    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
        guard let token = fcmToken else { return }
        print("📌 Firebase FCM 등록 토큰 수신: \(token)")
        
        do {
            let cached = try TokenKeychainManager.shared.getFCMToken()
            
            if cached == token {
                print("기존 FCM 토큰과 동일 → 서버 전송 생략")
            } else {
                try TokenKeychainManager.shared.saveFCMToken(token)
                print("FCM 토큰 저장 완료 & 서버 동기화 필요")
                
                // 서버에 최신 FCM 토큰 전송
                // MyAPIService.shared.updateFCMToken(token)
            }
            
        } catch {
            // Keychain 조회 실패 → 그냥 새 값 저장
            do {
                try TokenKeychainManager.shared.saveFCMToken(token)
                print("📌 FCM 토큰 신규 저장 완료 & 서버 동기화 필요")
                
                // 서버에 최신 FCM 토큰 전송
                // MyAPIService.shared.updateFCMToken(token)
            } catch {
                print("❌ FCM 토큰 저장 실패: \(error)")
            }
        }
    }

}
```


`AuthSession`
- 자동 로그인 에러 해결 초기 진입시 엑세스 토큰 만료시 리프래시 갱신 로직을 추가함
- 로그아웃, 탈퇴처리 로직 구현
```swift
    func autoLoginOnLaunch() {
        // 1. AccessToken이 유효 → 바로 로그인 유지
        if let access = try? TokenKeychainManager.shared.getAccessToken(),
           !access.isEmpty,
           !TokenKeychainManager.shared.isTokenExpired(access) {
            print("AccessToken 유효 → 로그인 유지")
            isLoggedIn = true
            return
        }
        
        // 2. AccessToken이 없거나 만료 → Refresh 시도
        RefreshService.refreshTokens { result in
            switch result {
            case .success(let tokenData):
                do {
                    try TokenKeychainManager.shared.saveAccessToken(tokenData.accessToken)
                    try TokenKeychainManager.shared.saveRefreshToken(tokenData.refreshToken)
                    print("AccessToken만료 -> Refresh 성공 → 새 토큰 저장")
                    
                    DispatchQueue.main.async {
                        self.isLoggedIn = true
                    }
                } catch {
                    print("❌ 새 토큰 저장 실패: \(error.localizedDescription)")
                    DispatchQueue.main.async {
                        self.isLoggedIn = false
                    }
                }
                
            case .failure(let error):
                print("❌ Refresh 실패: \(error.localizedDescription)")
                DispatchQueue.main.async {
                    self.isLoggedIn = false
                }
            }
        }
    }

   // MARK: - 로그아웃

    func logout() {
        print("로그아웃 실행: 세션/토큰 정리")
        clear()
        GIDSignIn.sharedInstance.signOut()
        try? Auth.auth().signOut()
    }
    
    // MARK: - 회원 탈퇴

    func withdraw() async {
        guard let _ = try? keychain.getAccessToken() else {
            print("⚠️ AccessToken 없음 → 탈퇴 API 호출 생략")
            clear()
            return
        }
        
        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
            memberService.withdraw { result in
                switch result {
                case .success:
                    print("회원 탈퇴 성공")
                    self.logout() // 로그아웃과 동일하게 세션 정리
                case .unAuthorized:
                    print("401 Unauthorized: 이미 만료된 토큰")
                    self.clear()
                default:
                    print("회원 탈퇴 실패(서버 오류)")
                }
                cont.resume()
            }
        }
    }
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #12 
