### PR TITLE
[Feat] #51 - 로그인 Firebase Auth 연동, SettingView 약관, 피드백, 로그인 계정 표시

### DIFF
--- a/Memento-iOS/Memento-iOS.xcodeproj/project.pbxproj
+++ b/Memento-iOS/Memento-iOS.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 				Source/Presentation/Main/View/Common/AlertOverlay.swift,
 				Source/Presentation/Main/View/Common/DropViewDelegate.swift,
 				Source/Presentation/Main/View/ToDoList/ToDoListWeeklyCalendarView.swift,
+				Source/Presentation/Onboarding/View/StartMementoView.swift,
 				Source/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift,
 				Source/Utils/DynamicPresentationDetent.swift,
 			);

--- a/Memento-iOS/Memento-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Memento-iOS/Memento-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dev-memento/memento-design-system-iOS",
       "state" : {
-        "revision" : "2fcced5f3c148a8ce0fcb51a5f609a77403735ba",
-        "version" : "1.0.15"
+        "revision" : "622ef695469cd8df6049cba8be747c8f4c39cff4",
+        "version" : "1.0.16"
       }
     },
     {

--- a/Memento-iOS/Memento-iOS/Source/Const/StringLiteral.swift
+++ b/Memento-iOS/Memento-iOS/Source/Const/StringLiteral.swift
@@ -57,7 +57,12 @@ enum StringLiteral {
             static let calendarConnectHeaderTitle = "기존의 사용하던 캘린더로부터 일정을 불러옵니다."
             static let connectGoogleCalendar = "Connect Google Calendar"
             static let connectAppleCalendar = "Connect Apple Calendar"
-            static let startMementoButton = "Start MEMENTO"
+            static let startMementoButton = "START MEMENTO"
+        }
+        
+        enum StartMementoView {
+            static let startMementoTitle = "MEMENTO와 함께 당신의 삶을 동기화하세요"
+            static let startMementoButton = "START MEMENTO"
         }
 
         static let nextButton = "Next"
@@ -146,6 +151,7 @@ typealias OnboardingSleepCycleText = StringLiteral.Onboarding.SleepCycleSettingV
 typealias OnboardingWorkSelectionText = StringLiteral.Onboarding.WorkSelectionView
 typealias OnboardingWorkPreferenceText = StringLiteral.Onboarding.WorkPreferenceView
 typealias OnboardingCalendarConnectText = StringLiteral.Onboarding.CalendarConnectView
+typealias OnboardingStartMementoViewText = StringLiteral.Onboarding.StartMementoView
 typealias OnboardingPublicText = StringLiteral.Onboarding
 typealias SettingsSettingViewText = StringLiteral.Setting.SettingView
 typealias SettingsTimeViewText = StringLiteral.Setting.TimeView

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Apple.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Apple.swift
@@ -9,42 +9,105 @@ import Foundation
 
 import AuthenticationServices
 import FirebaseMessaging
-
+import FirebaseAuth
+import CryptoKit
 
 // MARK: - APPLE 로그인 이후 idToken 가져오기 담당
 
 @MainActor
 extension AuthSession {
+    
+    // MARK: Apple 로그인 요청 준비
     func prepareAppleSignIn(_ request: ASAuthorizationAppleIDRequest) {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        request.nonce = sha256(nonce)
         request.requestedScopes = [.fullName, .email]
         request.requestedOperation = .operationLogin
     }
-
+    
+    // MARK: Apple 로그인 완료 핸들러
     func handleAppleSignInCompletion(_ result: Result<ASAuthorization, Error>) {
         Task { @MainActor in
             guard !isLoading else { return }
             isLoading = true
             defer { isLoading = false }
-
+            
             switch result {
             case .success(let authorization):
                 await processAppleAuthorization(authorization)
             case .failure(let error):
-                handleError(error, defaultMessage: "Apple 로그인 실패")
+                print("Apple 로그인 실패: \(error.localizedDescription)")
             }
         }
     }
-
+    
+    // MARK: Firebase 세션 연결
     fileprivate func processAppleAuthorization(_ authorization: ASAuthorization) async {
         guard
             let cred = authorization.credential as? ASAuthorizationAppleIDCredential,
             let idTokenData = cred.identityToken,
-            let idTokenString = String(data: idTokenData, encoding: .utf8)
+            let idTokenString = String(data: idTokenData, encoding: .utf8),
+            let nonce = currentNonce
         else {
-            handleError(nil, defaultMessage: "Apple 사용자 인증 정보 누락")
+            print("Apple 사용자 인증 정보 누락")
             return
         }
-
-        await requestLogin(provider: "APPLE", idToken: idTokenString)
+        
+        // Firebase Credential 생성
+        let firebaseCredential = OAuthProvider.credential(
+            withProviderID: "apple.com",
+            idToken: idTokenString,
+            rawNonce: nonce
+        )
+        
+        do {
+            // Firebase 로그인 (세션 연결)
+            let result = try await Auth.auth().signIn(with: firebaseCredential)
+            isLoggedIn = true
+            
+            // 서버에도 로그인 요청
+            await requestLogin(provider: "APPLE", idToken: idTokenString)
+            
+        } catch {
+            print("Firebase 세션 연결 실패: \(error.localizedDescription)")
+        }
+    }
+    
+    /// Apple → Firebase 로그인 연결할 때 리플레이 공격 방지를 위해 nonce(랜덤 문자열)를 사용
+    func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0..<16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+            
+            randoms.forEach { random in
+                if remainingLength == 0 { return }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        
+        return result
+    }
+    
+    /// SHA256 변환 (Firebase가 검증할 때 필요)
+    func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Apple.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Apple.swift
@@ -64,7 +64,6 @@ extension AuthSession {
         do {
             // Firebase 로그인 (세션 연결)
             let result = try await Auth.auth().signIn(with: firebaseCredential)
-            isLoggedIn = true
             
             // 서버에도 로그인 요청
             await requestLogin(provider: "APPLE", idToken: idTokenString)

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Apple.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Apple.swift
@@ -18,6 +18,10 @@ import CryptoKit
 extension AuthSession {
     
     // MARK: Apple 로그인 요청 준비
+    /// Apple 로그인 요청을 초기화할 때 호출되는 메서드.
+    /// - nonce(랜덤 문자열)를 생성해 요청에 심어 넣음 → 보안 공격(리플레이 공격) 방지.
+    /// - 로그인 시 사용자 정보(fullName, email) 스코프 요청.
+
     func prepareAppleSignIn(_ request: ASAuthorizationAppleIDRequest) {
         let nonce = randomNonceString()
         currentNonce = nonce
@@ -27,6 +31,10 @@ extension AuthSession {
     }
     
     // MARK: Apple 로그인 완료 핸들러
+    /// Apple 로그인 UI 완료 후 결과(Result)를 받아 처리하는 메서드.
+    /// - 성공 시: `processAppleAuthorization` 호출.
+    /// - 실패 시: 에러 메시지 출력.
+    
     func handleAppleSignInCompletion(_ result: Result<ASAuthorization, Error>) {
         Task { @MainActor in
             guard !isLoading else { return }
@@ -43,6 +51,11 @@ extension AuthSession {
     }
     
     // MARK: Firebase 세션 연결
+    /// Apple 로그인 성공 시 내려온 credential에서 idToken 추출 후 Firebase Auth와 연결.
+    /// - Apple ID Credential에서 identityToken 추출.
+    /// - Firebase OAuthCredential 생성 후 `Auth.auth().signIn` 실행.
+    /// - Firebase 세션 연결 성공 시, 서버 API 로그인까지 요청.
+    
     fileprivate func processAppleAuthorization(_ authorization: ASAuthorization) async {
         guard
             let cred = authorization.credential as? ASAuthorizationAppleIDCredential,

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
@@ -38,39 +38,54 @@ extension AuthSession {
             
             GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
             
-            guard let rootVC = UIApplication.shared.keyWindow?.rootViewController else {
+            guard
+                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                let rootVC = windowScene.windows.first?.rootViewController
+            else {
                 handleError(nil, defaultMessage: "루트 뷰 컨트롤러를 찾을 수 없습니다.")
                 return
             }
             
-            GIDSignIn.sharedInstance.signIn(withPresenting: rootVC) { [weak self] result, error in
-                Task { @MainActor in
-                    guard let self else { return }
-                    if let result { await self.authenticateGoogleUser(for: result.user, with: error) }
-                    else { self.handleError(error, defaultMessage: "Google 로그인 실패") }
-                }
+            do {
+                let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: rootVC)
+                await authenticateGoogleUser(for: result.user, with: nil)
+            } catch {
+                handleError(error, defaultMessage: "Google 로그인 실패")
             }
-        }
-    }
-    
-    func signOut() {
-        GIDSignIn.sharedInstance.signOut()
-        do {
-            try Auth.auth().signOut()
-            print("Google 로그아웃 성공")
-        } catch {
-            print("Google 로그아웃 실패: \(error.localizedDescription)")
         }
     }
     
     fileprivate func authenticateGoogleUser(for user: GIDGoogleUser?, with error: Error?) async {
         defer { isLoading = false }
-        if let error { handleError(error, defaultMessage: "Google 로그인 실패"); return }
         
-        guard let idToken = user?.idToken?.tokenString else {
+        if let error {
+            handleError(error, defaultMessage: "Google 로그인 실패")
+            return
+        }
+        
+        guard
+            let idToken = user?.idToken?.tokenString,
+            let accessToken = user?.accessToken.tokenString
+        else {
             handleError(nil, defaultMessage: "Google 사용자 토큰 누락")
             return
         }
-        await requestLogin(provider: "GOOGLE", idToken: idToken)
+        
+        let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
+        
+        do {
+            
+            // Firebase 로그인 (세션 연결)
+            let result = try await Auth.auth().signIn(with: credential)
+            let firebaseUser = result.user
+          
+            isLoggedIn = true
+            
+            // 서버에도 로그인 요청
+            await requestLogin(provider: "GOOGLE", idToken: idToken)
+            
+        } catch {
+            handleError(error, defaultMessage: "Firebase 세션 연결 실패")
+        }
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
@@ -87,7 +87,6 @@ extension AuthSession {
             
             // Firebase 로그인 (세션 연결)
             let result = try await Auth.auth().signIn(with: credential)
-            let firebaseUser = result.user
             
             // 서버에도 로그인 요청
             await requestLogin(provider: "GOOGLE", idToken: idToken)

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
@@ -78,8 +78,6 @@ extension AuthSession {
             // Firebase 로그인 (세션 연결)
             let result = try await Auth.auth().signIn(with: credential)
             let firebaseUser = result.user
-          
-            isLoggedIn = true
             
             // 서버에도 로그인 요청
             await requestLogin(provider: "GOOGLE", idToken: idToken)

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Google.swift
@@ -16,6 +16,12 @@ import FirebaseMessaging
 
 @MainActor
 extension AuthSession {
+    
+    // MARK: Google 로그인 요청을 시작하는 메서드.
+    /// - 이미 로그인된 세션이 있다면 `restorePreviousSignIn`으로 복구.
+    /// - 없으면 새롭게 Google 로그인 플로우 시작.
+    /// - 로그인 완료 시 `authenticateGoogleUser` 호출.
+
     func signInWithGoogle() {
         Task { @MainActor in
             guard !isLoading else { return }
@@ -55,6 +61,10 @@ extension AuthSession {
         }
     }
     
+    // MARK: Google 로그인 완료 후 사용자 인증 정보를 처리하는 메서드.
+    /// - idToken, accessToken 추출.
+    /// - Firebase Auth Credential 생성.
+    /// - Firebase 세션 연결 후 서버 로그인 요청 실행.
     fileprivate func authenticateGoogleUser(for user: GIDGoogleUser?, with error: Error?) async {
         defer { isLoading = false }
         

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Network.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession+Network.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import FirebaseMessaging
+import FirebaseAuth
 
 @MainActor
 extension AuthSession {
@@ -18,20 +19,20 @@ extension AuthSession {
         do {
             // 1. Keychain에 저장된 FCM 토큰 확인
             let cachedToken = try? keychain.getFCMToken()
-              
-              // 2. Firebase에서 최신 토큰 가져오기
-              let newToken = try await Messaging.messaging().token()
-              
-              // 3. 캐시와 비교 후 필요한 경우만 서버 전송
-              let fcmTokenToSend: String
-              if cachedToken == newToken {
-                  print("📌 기존 FCM 토큰과 동일 → 캐시 사용")
-                  fcmTokenToSend = cachedToken ?? newToken
-              } else {
-                  print("📌 새로운 FCM 토큰 감지 → 저장 & 전송")
-                  try? keychain.saveFCMToken(newToken)
-                  fcmTokenToSend = newToken
-              }
+            
+            // 2. Firebase에서 최신 토큰 가져오기
+            let newToken = try await Messaging.messaging().token()
+            
+            // 3. 캐시와 비교 후 필요한 경우만 서버 전송
+            let fcmTokenToSend: String
+            if cachedToken == newToken {
+                print("📌 기존 FCM 토큰과 동일 → 캐시 사용")
+                fcmTokenToSend = cachedToken ?? newToken
+            } else {
+                print("📌 새로운 FCM 토큰 감지 → 저장 & 전송")
+                try? keychain.saveFCMToken(newToken)
+                fcmTokenToSend = newToken
+            }
             
             let timeZoneOffset = Self.currentTimeZoneOffset()
             
@@ -65,20 +66,25 @@ extension AuthSession {
                         self.isLoading = false
                         
                     case .unAuthorized:
-                        self.errorMessage = "인증 실패. 다시 로그인하세요."
-                        self.isLoading = false
+                        self.handleServerError("인증 실패. 다시 로그인하세요.")
                         
                     default:
-                        self.errorMessage = "서버 오류가 발생했습니다."
-                        self.isLoading = false
+                        self.handleServerError("서버 오류가 발생했습니다.")
                     }
                 }
             }
         } catch {
-            handleError(error, defaultMessage: "FCM 토큰을 가져올 수 없습니다.")
+            self.handleServerError("로그인 중 예외 발생: \(error.localizedDescription)")
         }
     }
     
+    /// 서버 로그인 실패 시 Firebase 세션도 정리
+    private func handleServerError(_ message: String) {
+        print("🚨 서버 로그인 실패: \(message)")
+        try? Auth.auth().signOut()
+        clear()
+        self.errorMessage = message
+    }
     
     func setTokens(accessToken: String, refreshToken: String) {
         let acc = accessToken.replacingOccurrences(of: "Bearer ", with: "")

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
@@ -104,6 +104,7 @@ final class AuthSession: ObservableObject {
     }
     
     // MARK: - 로그아웃
+    
     func logout() {
         print("로그아웃 실행: 세션/토큰 정리")
         clear()
@@ -112,6 +113,7 @@ final class AuthSession: ObservableObject {
     }
     
     // MARK: - 회원 탈퇴
+    
     func withdraw() async {
         guard let _ = try? keychain.getAccessToken() else {
             print("⚠️ AccessToken 없음 → 탈퇴 API 호출 생략")

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
@@ -65,6 +65,7 @@ final class AuthSession: ObservableObject {
     // MARK: - 자동 로그인
     
     func autoLoginOnLaunch() {
+
         // 1. AccessToken이 유효 → 바로 로그인 유지
         if let access = try? TokenKeychainManager.shared.getAccessToken(),
            !access.isEmpty,

--- a/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
+++ b/Memento-iOS/Memento-iOS/Source/Network/Base/AuthSession/AuthSession.swift
@@ -34,6 +34,9 @@ final class AuthSession: ObservableObject {
         keychain.hasValidToken()
     }
     
+    /// Apple 로그인 공격 방지용
+    var currentNonce: String?
+    
     private init() {
         isLoggedIn = keychain.hasValidToken()
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/CalendarConnectView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/CalendarConnectView.swift
@@ -33,9 +33,7 @@ struct CalendarConnectView: View {
 
                 Spacer()
 
-                AppStartButton()
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 10)
+                // 추후 버튼 위치
             }
         }
     }
@@ -178,36 +176,9 @@ private struct CalendarConnectButtons: View {
         }
     }
 }
-private struct AppStartButton: View {
-    @EnvironmentObject var viewModel: OnboardingViewModel
-    @EnvironmentObject var authSession: AuthSession
-
-    var body: some View {
-        Button {
-            // 1. 데이터 전송
-            viewModel.submitOnboardingData()
-            
-            // 2. 전송 성공 시 → 세션 갱신
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                withAnimation(.easeInOut) {
-                    authSession.shouldStartOnboarding = false
-                    authSession.isLoggedIn = true
-                }
-            }
-        } label: {
-            Text(OnboardingCalendarConnectText.startMementoButton)
-                .applyFont(.body_b_16)
-                .foregroundColor(Color.black)
-                .padding(.vertical, 13)
-                .frame(maxWidth: .infinity)
-        }
-        .background(Color.mainGreen)
-        .frame(height: 50)
-        .cornerRadius(2)
-        .disabled(!authSession.shouldStartOnboarding)
-    }
-}
 
 #Preview {
-    CalendarConnectView().environmentObject(OnboardingViewModel())
+    CalendarConnectView()
+        .environmentObject(OnboardingViewModel())
+        .environmentObject(AuthSession.shared)
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/LoginView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/LoginView.swift
@@ -54,8 +54,8 @@ struct LoginView: View {
                     WorkPreferenceView()
                         .navigationBarBackButtonHidden()
                         .environmentObject(viewModel)
-                case .calendarConnect:
-                    CalendarConnectView()
+                case .startMemento:
+                    StartMementoView()
                         .navigationBarBackButtonHidden()
                         .environmentObject(viewModel)
                         .environmentObject(authSession)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/SleepCycleSettingView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/SleepCycleSettingView.swift
@@ -25,7 +25,7 @@ struct SleepCycleSettingView: View {
                         viewModel.navigateBack()
                     },
                     skipButtonAction: {
-                        viewModel.navigateToNext(.calendarConnect)
+                        viewModel.navigateToNext(.startMemento)
                     }
                 )
                 .padding([.trailing, .top], 16)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/StartMementoView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/StartMementoView.swift
@@ -1,0 +1,85 @@
+//
+//  StartMementoView.swift
+//  Memento-iOS
+//
+//  Created by jeonguk29 on 9/2/25.
+//
+
+import SwiftUI
+import MDSKit
+
+struct StartMementoView: View {
+    @EnvironmentObject var viewModel: OnboardingViewModel
+
+    var body: some View {
+        VStack(alignment: .center) {
+            CustomNavigationBar(
+                showBackButton: true,
+                showSkipButton: false,
+                backButtonAction: {
+                    viewModel.navigateBack()
+                }
+            )
+            .padding([.trailing, .top], 16)
+            
+            Text(OnboardingStartMementoViewText.startMementoTitle)
+                .applyFont(.title_b_24)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.white)
+                .padding(.top, 98)
+
+            Spacer()
+
+            AppStartButton()
+                .padding(.horizontal, 16)
+                .padding(.bottom, 10)
+        }
+        .background {
+            Image(.img_bg_start)
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+        }
+    }
+}
+private struct AppStartButton: View {
+    @EnvironmentObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var authSession: AuthSession
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Image(.ic_start_character)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 58.46, height: 56.62)
+            Button {
+                // 1. 데이터 전송
+                viewModel.submitOnboardingData()
+                
+                // 2. 전송 성공 시 → 세션 갱신
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    withAnimation(.easeInOut) {
+                        authSession.shouldStartOnboarding = false
+                        authSession.isLoggedIn = true
+                    }
+                }
+            } label: {
+                Text(OnboardingStartMementoViewText.startMementoButton)
+                    .applyFont(.body_b_16)
+                    .foregroundColor(Color.white)
+                    .padding(EdgeInsets(top: 13, leading: 0, bottom: 13, trailing: 0))
+                    .frame(maxWidth: .infinity)
+            }
+            .background(Color.black)
+            .frame(height: 50)
+            .cornerRadius(2)
+            .disabled(!authSession.shouldStartOnboarding)
+        }
+    }
+}
+
+#Preview {
+    StartMementoView()
+        .environmentObject(OnboardingViewModel())
+        .environmentObject(AuthSession.shared)
+}

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/StartMementoView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/StartMementoView.swift
@@ -55,14 +55,7 @@ private struct AppStartButton: View {
             Button {
                 // 1. 데이터 전송
                 viewModel.submitOnboardingData()
-                
-                // 2. 전송 성공 시 → 세션 갱신
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    withAnimation(.easeInOut) {
-                        authSession.shouldStartOnboarding = false
-                        authSession.isLoggedIn = true
-                    }
-                }
+            
             } label: {
                 Text(OnboardingStartMementoViewText.startMementoButton)
                     .applyFont(.body_b_16)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/WorkPreferenceView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/WorkPreferenceView.swift
@@ -23,7 +23,7 @@ struct WorkPreferenceView: View {
                         viewModel.navigateBack()
                     },
                     skipButtonAction: {
-                        viewModel.navigateToNext(.calendarConnect)
+                        viewModel.navigateToNext(.startMemento)
                     }
                 )
                 .padding([.trailing, .top], 16)
@@ -126,7 +126,7 @@ private struct NextButton: View {
     var body: some View {
         Button {
             if viewModel.isNextButtonEnabledForWorkPreference {
-                viewModel.navigateToNext(.calendarConnect)
+                viewModel.navigateToNext(.startMemento)
             }
         } label: {
             Text(OnboardingPublicText.nextButton)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/WorkSelectionView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/View/WorkSelectionView.swift
@@ -28,7 +28,7 @@ struct WorkSelectionView: View {
                         viewModel.navigateBack()
                     },
                     skipButtonAction: {
-                        viewModel.navigateToNext(.calendarConnect)
+                        viewModel.navigateToNext(.startMemento)
                     }
                 )
                 .padding([.trailing, .top], 16)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -17,7 +17,7 @@ enum OnboardingNavigationDestination: String, Hashable {
     case sleepCycleSetting = "SleepCycleSettingView"
     case workSelection = "WorkSelectionView"
     case workPreference = "WorkPreferenceView"
-    case calendarConnect = "CalendarConnectView"
+    case startMemento = "StartMementoView"
 }
 
 // MARK: - Data Models

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
@@ -199,16 +199,26 @@ struct SettingView: View {
         
         var body: some View {
             VStack {
-                SettingsRowButton(
-                    title: SettingsSettingViewText.feedback,
-                    action: { viewModel.navigateToNext(.Feedback) }
-                )
-                
-                SettingsRowButton(
-                    title: SettingsSettingViewText.terms,
-                    action: { viewModel.navigateToNext(.Terms) }
-                )
-                
+                HStack {
+                    Link(SettingsSettingViewText.feedback, destination: URL(string: "https://memento.featurebase.app/en")!)
+                        .applyFont(.body_r_14)
+                        .foregroundColor(Color.gray05)
+                    
+                    Spacer()
+                }
+                .padding(.top, 15)
+                .padding(.horizontal, 26)
+           
+                HStack {
+                    Link(SettingsSettingViewText.terms, destination: URL(string: "https://memento.today/terms")!)
+                        .applyFont(.body_r_14)
+                        .foregroundColor(Color.gray05)
+                    
+                    Spacer()
+                }
+                .padding(.top, 15)
+                .padding(.horizontal, 26)
+
                 SettingsRowDivider()
             }
         }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import MDSKit
 
+import FirebaseAuth
+
 struct SettingView: View {
     @EnvironmentObject var viewModel: SettingViewModel
     @EnvironmentObject var authSession: AuthSession
@@ -17,6 +19,10 @@ struct SettingView: View {
     @State private var showLogoutAlert = false
     @State private var showDeleteAlert = false
     
+    private var userEmail: String {
+        Auth.auth().currentUser?.email ?? "이메일 없음"
+    }
+
     var body: some View {
         NavigationStack(path: $viewModel.navigationPath) {
             ZStack {
@@ -30,7 +36,7 @@ struct SettingView: View {
                         )
                         .padding(.top, 25)
                         
-                        UserInfoCard()
+                        UserInfoCard(userEmail: userEmail)
                         
                         GeneralSettingsSection()
                         
@@ -118,6 +124,8 @@ struct SettingView: View {
     }
     
     struct UserInfoCard: View {
+        var userEmail: String
+        
         var body: some View {
             HStack(spacing: 15) {
                 Image(.img_logo_memento_white)
@@ -125,7 +133,7 @@ struct SettingView: View {
                     .scaledToFit()
                     .frame(width: 46, height: 44)
                 
-                Text(verbatim: "memento@gmail.com")
+                Text(verbatim: userEmail)
                     .applyFont(.body_b_14)
                     .foregroundColor(Color.gray04)
                 


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- StartMementoView 구현
- 약관, 피드백 링크 연결 (설정 화면 → 웹뷰 연동)
- Google 로그인 Firebase Auth 연동
    - Google OAuth → Firebase Credential 변환 → 세션 연결 -> 서버 로그인 요청 연동
- Apple 로그인 Firebase Auth 연동
   - nonce 생성/검증 로직 추가 ->  Firebase Credential 변환 → 세션 연결 -> 서버 로그인 요청 연동
- SettingView 사용자 이메일 표시 (FirebaseAuth currentUser.email 표시)

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/1531b430-7f91-47d5-8245-8438e4b9310f" width ="250"> | <img src = "https://github.com/user-attachments/assets/1531b430-7f91-47d5-8245-8438e4b9310f" width ="250"> | <img src = "https://github.com/user-attachments/assets/1531b430-7f91-47d5-8245-8438e4b9310f" width ="250"> |


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->

### 소셜 로그인 공통 흐름 (Google & Apple)

1. **OAuth 로그인 요청**
    - Google: `GIDSignIn.sharedInstance.signIn(...)`
    - Apple: `ASAuthorizationAppleIDProvider().createRequest()`
2. **토큰 획득**
    - Google: `idToken`, `accessToken`
    - Apple: `idToken` (+ `nonce` 검증 필수)
3. **Firebase Credential 변환**
    - Google → `GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)`
    - Apple → `OAuthProvider.credential(withProviderID: "apple.com", idToken: idToken, rawNonce: nonce)`
4. **Firebase Auth 세션 연결**
    
    ```swift
    let result = try await Auth.auth().signIn(with: credential)
    
    // 사용자 로그인 이메일 가져오는 코드
    private var userEmail: String {
         Auth.auth().currentUser?.email ?? "이메일 없음"
    }
    
    //아래와 같은 값 사용가능
    if let user = Auth.auth().currentUser {
        print("UID: \(user.uid)")
        print("Email: \(user.email ?? "이메일 없음")")
        print("DisplayName: \(user.displayName ?? "이름 없음")")
    }
    ```
    
    → `Auth.auth().currentUser`가 채워지고, 앱 전역에서 로그인 상태 확인 가능
    
5. **서버 로그인 요청 연동**
    - 획득한 `idToken`을 서버 API에 전달
    - 서버에서 자체 세션/회원 관리 수행

---


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #51 
