### PR TITLE
[Fix] #64 - 1차 QA

### DIFF
--- a/Memento-iOS/Memento-iOS/Source/Component/Alert/ScheduleAlertView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Component/Alert/ScheduleAlertView.swift
@@ -111,7 +111,7 @@ struct ScheduleAlertView: View {
             .padding(.bottom, 26)
             .padding(.horizontal, 24)
         }
-        .frame(width: 343, height: 332)
+        .frame(width: 343, height: 300)
         .background(Color.gray10)
         .cornerRadius(2)
     }

--- a/Memento-iOS/Memento-iOS/Source/Component/Cache/APICacheLogger.swift
+++ b/Memento-iOS/Memento-iOS/Source/Component/Cache/APICacheLogger.swift
@@ -17,13 +17,13 @@ final class APICacheLogger {
     func logServerCall(start: Date, apiName: String) {
         let elapsed = Date().timeIntervalSince(start) * 1000
         serverTimes[apiName, default: []].append(elapsed)
-        print("📌 [SERVER] \(apiName) — \(String(format: "%.2f", elapsed))ms")
+//        print("📌 [SERVER] \(apiName) — \(String(format: "%.2f", elapsed))ms")
     }
 
     func logCacheCall(start: Date, apiName: String) {
         let elapsed = Date().timeIntervalSince(start) * 1000
         cacheTimes[apiName, default: []].append(elapsed)
-        print("📌 [CACHE] \(apiName) — \(String(format: "%.2f", elapsed))ms")
+//        print("📌 [CACHE] \(apiName) — \(String(format: "%.2f", elapsed))ms")
     }
 
     /// 캐시 vs 서버 개선율 + 일반 통계 모두 출력

--- a/Memento-iOS/Memento-iOS/Source/Component/TabBar/TabBarView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Component/TabBar/TabBarView.swift
@@ -95,7 +95,7 @@ struct TabBarView: View {
                 Color.black.opacity(0.5)
                     .ignoresSafeArea(.all)
                     .onTapGesture {
-                        dismissKeyboard()
+                        self.hideKeyboard()
                         segmentedViewModel.isPresented = false
                         segmentedViewModel.selectedMenu = .checkbox
                     }
@@ -113,7 +113,7 @@ struct TabBarView: View {
                             }
                             .onEnded { value in
                                 if value.translation.height > segmentedViewHeight / 3 {
-                                    dismissKeyboard()
+                                    self.hideKeyboard()
                                     segmentedViewModel.isPresented = false
                                     segmentedViewModel.selectedMenu = .checkbox
                                 }
@@ -131,14 +131,5 @@ struct TabBarView: View {
                 EditToDoView(isEditViewPresented: $isEditToDoSheetPresented, toDoItem: item)
             }
         }
-    }
-    
-    private func dismissKeyboard() {
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder),
-            to: nil,
-            from: nil,
-            for: nil
-        )
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Const/TimeInterval.swift
+++ b/Memento-iOS/Memento-iOS/Source/Const/TimeInterval.swift
@@ -10,4 +10,5 @@ import Foundation
 extension TimeInterval {
 
     static let oneDay: TimeInterval = 24 * 60 * 60
+    static let twoHours: TimeInterval = 2 * 60 * 60
 }

--- a/Memento-iOS/Memento-iOS/Source/Extension/Date+.swift
+++ b/Memento-iOS/Memento-iOS/Source/Extension/Date+.swift
@@ -129,4 +129,16 @@ extension Date {
         
         return false
     }
+    
+    /// post Schecule 을 위한 날짜 시간 결합
+    func combineDateAndTime(date: Date, time: Date) -> Date {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.hour, .minute, .second], from: time)
+        return calendar.date(
+            bySettingHour: components.hour ?? 0,
+            minute: components.minute ?? 0,
+            second: components.second ?? 0,
+            of: date
+        ) ?? date
+    }
 }

--- a/Memento-iOS/Memento-iOS/Source/Extension/View+.swift
+++ b/Memento-iOS/Memento-iOS/Source/Extension/View+.swift
@@ -31,4 +31,13 @@ extension View {
             self.presentationDetents([.fraction(0.33)])
         }
     }
+    
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/SegmentedMenuView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/SegmentedMenuView.swift
@@ -36,7 +36,7 @@ struct SegmentedMenuView: View {
         }
         .ignoresSafeArea(.all, edges: .bottom)
         .onTapGesture {
-            hideKeyboard()
+            self.hideKeyboard()
         }
     }
 }
@@ -79,14 +79,5 @@ extension SegmentedMenuView {
         case .event:
             AddScheduleView(isAddViewPresented: $viewModel.isPresented)
         }
-    }
-    
-    private func hideKeyboard() {
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder),
-            to: nil,
-            from: nil,
-            for: nil
-        )
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/SegmentedMenuView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Common/View/SegmentedMenuView.swift
@@ -35,6 +35,9 @@ struct SegmentedMenuView: View {
             .onAppear { sheetHeight = calculatedSheetHeight }
         }
         .ignoresSafeArea(.all, edges: .bottom)
+        .onTapGesture {
+            hideKeyboard()
+        }
     }
 }
 
@@ -76,5 +79,14 @@ extension SegmentedMenuView {
         case .event:
             AddScheduleView(isAddViewPresented: $viewModel.isPresented)
         }
+    }
+    
+    private func hideKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/View/AddScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/View/AddScheduleView.swift
@@ -25,7 +25,7 @@ struct AddScheduleView: View {
         ZStack {
             Color.gray10.ignoresSafeArea()
                 .onTapGesture {
-                    hideKeyboard()
+                    self.hideKeyboard()
                 }
             
             VStack {
@@ -214,11 +214,10 @@ struct AddScheduleView: View {
             Spacer()
             
             Button {
-                viewModel.postSchedule {
-                    withAnimation(.spring()) {
-                        isAddViewPresented = false
-                    }
+                withAnimation(.spring()) {
+                    isAddViewPresented = false
                 }
+                viewModel.postSchedule { }
             } label: {
                 Image( viewModel.isTextEmpty ? .btn_enter_disabled : .btn_enter_active)
             }
@@ -226,14 +225,5 @@ struct AddScheduleView: View {
             .padding(.bottom, 40)
             .disabled(viewModel.isTextEmpty)
         }
-    }
-    
-    private func hideKeyboard() {
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder),
-            to: nil,
-            from: nil,
-            for: nil
-        )
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/View/AddScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/View/AddScheduleView.swift
@@ -152,20 +152,19 @@ struct AddScheduleView: View {
         HStack {
             Spacer()
             
-            Button(action: viewModel.toggleAllDay) {
+            Button(action: {
+                viewModel.isAllDay.toggle()
+            }) {
                 HStack(spacing: 10) {
                     Image(viewModel.isAllDay ? .btn_check_selected_square : .btn_check_unselected_square)
                         .renderingMode(.template)
-                        .foregroundColor(viewModel.isOverOneDay() ? .gray05 : .gray07)
-                        .opacity(viewModel.isOverOneDay() ? 1.0 : 0.5)
+                        .foregroundColor(.gray05)
                     
                     Text(StringLiteral.AddSchedule.allDay)
                         .applyFont(.body_r_14)
-                        .foregroundColor(viewModel.isOverOneDay() ? .gray05 : .gray07)
-                        .opacity(viewModel.isOverOneDay() ? 1.0 : 0.5)
+                        .foregroundColor(.gray05)
                 }
             }
-            .disabled(!viewModel.isOverOneDay())
             .padding(.trailing, 11)
         }
         .padding(.top, 12)

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/View/AddScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/View/AddScheduleView.swift
@@ -24,6 +24,9 @@ struct AddScheduleView: View {
     var body: some View {
         ZStack {
             Color.gray10.ignoresSafeArea()
+                .onTapGesture {
+                    hideKeyboard()
+                }
             
             VStack {
                 CustomToggleView(isOn: $viewModel.isNaturalLanguageEnabled)
@@ -224,5 +227,14 @@ struct AddScheduleView: View {
             .padding(.bottom, 40)
             .disabled(viewModel.isTextEmpty)
         }
+    }
+    
+    private func hideKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
     }
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
@@ -34,21 +34,34 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     }
     
     @Published var startDate: Date = Date().startOfDay {
-        didSet { autoUpdateAllDayStatus() }
+        didSet { autoToggleAllDay() }
     }
     @Published var endDate: Date = Date().startOfDay {
-        didSet { autoUpdateAllDayStatus() }
+        didSet { autoToggleAllDay() }
     }
     @Published var startTime: Date = Date().roundedToNearestHalfHour() {
-        didSet { autoUpdateAllDayStatus() }
+        didSet { autoToggleAllDay() }
     }
     @Published var endTime: Date = Calendar.current.date(byAdding: .hour, value: 2, to: Date().roundedToNearestHalfHour()) ?? Date().roundedToNearestHalfHour() {
-        didSet { autoUpdateAllDayStatus() }
+        didSet { autoToggleAllDay() }
     }
     
     @Published var isAllDay: Bool = false {
         didSet {
-            updateTimeForAllDayStatus()
+            if isUpdatingAllDay { return }
+            
+            if isAllDay {
+                // All-Day 활성화 시 start/end Time을 startDate/endDate로 맞춤
+                startTime = startDate.startOfDay
+                endTime = endDate.startOfDay
+            } else {
+                isUpdatingAllDay = true
+                startDate = Date().startOfDay
+                endDate = Date().startOfDay
+                startTime = Date().roundedToNearestHalfHour()
+                endTime = Calendar.current.date(byAdding: .hour, value: 2, to: Date().roundedToNearestHalfHour()) ?? Date().roundedToNearestHalfHour()
+                isUpdatingAllDay = false
+            }
         }
     }
     
@@ -114,92 +127,29 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
         }
     }
     
-    // 날짜랑 시간 결합
-    func combineDateAndTime(date: Date, time: Date) -> Date {
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.hour, .minute, .second], from: time)
-        return calendar.date(
-            bySettingHour: components.hour ?? 0,
-            minute: components.minute ?? 0,
-            second: components.second ?? 0,
-            of: date
-        ) ?? date
-    }
-    
+    // Request DTO에 맞게 날짜 시간 결합
     func formatDate(date: Date, time: Date) -> String {
-        combineDateAndTime(date: date, time: time).stringFromDate(with: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        Date().combineDateAndTime(date: date, time: time).stringFromDate(with: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     }
     
-    // All-Day 상태면 Time Picker에 All-Day 표시
+    // isAllDay가 true 면 Time Picker에 All-Day 표시
     func formatTime(_ date: Date) -> String {
         isAllDay ? StringLiteral.AddSchedule.allDay : date.stringFromDate(with: "h:mm a")
     }
     
     // MARK: - All-Day Handling
     
-    // 사용자의 토글 여부
-    private var hasUserToggledAllDay: Bool = false
+    private var isUpdatingAllDay = false
     
-    // 시작&종료 날짜 시간
-    private var startDateTime: Date { combineDateAndTime(date: startDate, time: startTime) }
-    private var endDateTime: Date { combineDateAndTime(date: endDate, time: endTime) }
-    
-    // 시작일과 종료일 간의 일(day) 차이
-    private var dayDifference: Int {
-        Calendar.current.dateComponents([.day],
-                                        from: Calendar.current.startOfDay(for: startDate),
-                                        to: Calendar.current.startOfDay(for: endDate)).day ?? 0
-    }
-    
-    // 일정 기간이 하루 이상인지 여부
-    func isOverOneDay() -> Bool {
-        endDateTime.timeIntervalSince(startDateTime) >= .oneDay
-    }
-    
-    // All-Day 토글
-    func toggleAllDay() {
-        guard dayDifference < 2 else {
-            print("DEBUG: 2일 이상 일정은 All-Day 해제 불가")
-            return
-        }
+    private func autoToggleAllDay() {
+        if isUpdatingAllDay { return }
         
-        isAllDay.toggle()
-        hasUserToggledAllDay = true
-    }
-    
-    // All-Day 상태에 따라 시작/종료 시간을 자동으로 업데이트
-    func updateTimeForAllDayStatus() {
-        if isAllDay { // All-Day일 경우 시작/종료 시간을 날짜의 시작 시각으로 맞춤
-            startTime = startDate.startOfDay
-            endTime = endDate.startOfDay
-        } else { // 올데이가 아닐 경우, 적절히 반올림된 시간으로 설정
-            let start = Date().roundedToNearestHalfHour()
-            let end = Calendar.current.date(byAdding: .hour, value: 2, to: start) ?? start
-            
-            startTime = start
-            endTime = end
-        }
-    }
-    
-    // All-Day 상태가 활성화되어야 하는지 판단
-    func autoUpdateAllDayStatus() {
-        if hasUserToggledAllDay { return }
+        let startDateTime = Date().combineDateAndTime(date: startDate, time: startTime)
+        let endDateTime = Date().combineDateAndTime(date: endDate, time: endTime)
+        let interval = endDateTime.timeIntervalSince(startDateTime)
         
-        let autoAllDay: Bool
-        switch dayDifference {
-        case 2...:
-            autoAllDay = true
-        case 1, 0:
-            autoAllDay = isOverOneDay()
-        default:
-            autoAllDay = false
-        }
-        
-        if isAllDay != autoAllDay {
-            if isOverOneDay() && !isAllDay {
-                print("DEBUG: 사용자가 All-Day를 해제했지만 일정 기간이 24시간 이상이므로 isAllDay: true로 전송됨")
-            }
-            isAllDay = autoAllDay
+        if interval >= .oneDay && !isAllDay {
+            isAllDay = true
         }
     }
     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
@@ -36,9 +36,10 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     @Published var startDate: Date = Date().startOfDay {
         didSet { updateDateTimeAllDayState() }
     }
-    @Published var endDate: Date = Date().startOfDay {
+    @Published var endDate: Date = Calendar.current.date(byAdding: .hour, value: 2, to: Date())!.startOfDay {
         didSet { updateDateTimeAllDayState() }
     }
+    
     @Published var startTime: Date = Date().roundedToNearestHalfHour() {
         didSet { updateDateTimeAllDayState() }
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
@@ -15,7 +15,7 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     
     private var scheduleService: ScheduleAPIServiceProtocol
     
-    // MARK: - User Input
+    // MARK: - Published Properties
     
     @Published var isNaturalLanguageEnabled: Bool = false {
         didSet {
@@ -55,46 +55,33 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
                 endTime = endDate.startOfDay
             } else {
                 isUpdatingAllDay = true
-                startDate = Date().startOfDay
-                endDate = Date().startOfDay
-                startTime = Date().roundedToNearestHalfHour()
-                endTime = Calendar.current.date(byAdding: .hour, value: 2, to: Date().roundedToNearestHalfHour()) ?? Date().roundedToNearestHalfHour()
+                resetDatesToDefault()
                 isUpdatingAllDay = false
             }
         }
     }
     
     @Published var tagList: [Tag] = []
-    @Published var selectedTag: Tag
-    
+    @Published var selectedTag: Tag = {
+        if let untitledTag = TagManager.shared.getTag(by: "Untitled") {
+            return Tag(tagId: untitledTag.id, name: untitledTag.name, color: Color(hex: untitledTag.colorCode))
+        } else {
+            return Tag(tagId: 0, name: "Loading...", color: .gray05)
+        }
+    }()
+
     // MARK: - Initializer
     
     init(scheduleService: ScheduleAPIServiceProtocol = ScheduleAPIService()) {
         
         self.scheduleService = scheduleService
-        
-        if let untitledTag = TagManager.shared.getTag(by: "Untitled") {
-            self.selectedTag = Tag(tagId: untitledTag.id, name: untitledTag.name, color: Color(hex: untitledTag.colorCode))
-        } else {
-            self.selectedTag = Tag(tagId: 0, name: "Loading...", color: .gray05)
-        }
     }
     
-    // MARK: - Computed Properties
+    // MARK: - Description & Natural Language
     
     var isTextEmpty: Bool { description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     
-    var formattedStartDate: String { startDate.stringFromDate(with: "MMM d, yyyy") }
-    var formattedEndDate: String { endDate.stringFromDate(with: "MMM d, yyyy") }
-    
-    var formattedStartTime: String { formatTime(startTime) }
-    var formattedEndTime: String { formatTime(endTime) }
-    
-    var tagId: Int { selectedTag.tagId }
-    
     private var parseWorkItem: DispatchWorkItem?
-    
-    // MARK: - Date Time Helpers
     
     private func debouncedParse() {
         parseWorkItem?.cancel()
@@ -126,6 +113,14 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
         }
     }
     
+    // MARK: - Date Time Handling
+    
+    var formattedStartDate: String { startDate.stringFromDate(with: "MMM d, yyyy") }
+    var formattedEndDate: String { endDate.stringFromDate(with: "MMM d, yyyy") }
+    
+    var formattedStartTime: String { formatTime(startTime) }
+    var formattedEndTime: String { formatTime(endTime) }
+    
     // Request DTO에 맞게 날짜 시간 결합
     func formatDate(date: Date, time: Date) -> String {
         Date().combineDateAndTime(date: date, time: time).stringFromDate(with: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -140,6 +135,14 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     
     private var isUpdatingAllDay = false
     
+    private func resetDatesToDefault() {
+        startDate = Date().startOfDay
+        endDate = Date().startOfDay
+        startTime = Date().roundedToNearestHalfHour()
+        endTime = Calendar.current.date(byAdding: .hour, value: 2, to: Date().roundedToNearestHalfHour()) ?? Date().roundedToNearestHalfHour()
+    }
+    
+    // 24시간 이상 차이 나면 자동 All-day & 시간 업데이트
     private func updateDateTimeAllDayState() {
         if isUpdatingAllDay { return }
         

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/Schedule/ViewModel/AddScheduleViewModel.swift
@@ -34,16 +34,16 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     }
     
     @Published var startDate: Date = Date().startOfDay {
-        didSet { autoToggleAllDay() }
+        didSet { updateDateTimeAllDayState() }
     }
     @Published var endDate: Date = Date().startOfDay {
-        didSet { autoToggleAllDay() }
+        didSet { updateDateTimeAllDayState() }
     }
     @Published var startTime: Date = Date().roundedToNearestHalfHour() {
-        didSet { autoToggleAllDay() }
+        didSet { updateDateTimeAllDayState() }
     }
     @Published var endTime: Date = Calendar.current.date(byAdding: .hour, value: 2, to: Date().roundedToNearestHalfHour()) ?? Date().roundedToNearestHalfHour() {
-        didSet { autoToggleAllDay() }
+        didSet { updateDateTimeAllDayState() }
     }
     
     @Published var isAllDay: Bool = false {
@@ -51,7 +51,6 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
             if isUpdatingAllDay { return }
             
             if isAllDay {
-                // All-Day 활성화 시 start/end Time을 startDate/endDate로 맞춤
                 startTime = startDate.startOfDay
                 endTime = endDate.startOfDay
             } else {
@@ -141,12 +140,21 @@ final class AddScheduleViewModel: ObservableObject, TagSelectable {
     
     private var isUpdatingAllDay = false
     
-    private func autoToggleAllDay() {
+    private func updateDateTimeAllDayState() {
         if isUpdatingAllDay { return }
         
         let startDateTime = Date().combineDateAndTime(date: startDate, time: startTime)
         let endDateTime = Date().combineDateAndTime(date: endDate, time: endTime)
+        
         let interval = endDateTime.timeIntervalSince(startDateTime)
+        
+        if endDateTime <= startDateTime {
+            isUpdatingAllDay = true
+            let newEnd = Calendar.current.date(byAdding: .hour, value: 2, to: startDateTime) ?? startDateTime
+            endDate = Calendar.current.startOfDay(for: newEnd)
+            endTime = newEnd
+            isUpdatingAllDay = false
+        }
         
         if interval >= .oneDay && !isAllDay {
             isAllDay = true

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/ToDo/View/AddToDoToolbarView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/ToDo/View/AddToDoToolbarView.swift
@@ -113,11 +113,11 @@ struct AddToDoToolbarView: View {
     
     private var enterButtonView: some View {
         Button(action: {
-            viewModel.postToDo {
-                withAnimation(.spring()) {
-                    isAddViewPresented = false
-                }
+            self.hideKeyboard()
+            withAnimation(.spring()) {
+                isAddViewPresented = false
             }
+            viewModel.postToDo { }
         }) {
             Image(viewModel.isTextEmpty ? .btn_enter_disabled : .btn_enter_active)
         }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/ToDo/ViewModel/AddToDoViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/ToDo/ViewModel/AddToDoViewModel.swift
@@ -33,8 +33,21 @@ final class AddToDoViewModel: ObservableObject, TagSelectable {
         }
     }
     
-    @Published var startDate: Date = Date()
-    @Published var endDate: Date = Date()
+    @Published var startDate: Date = Date() {
+        didSet {
+            if startDate > endDate {
+                endDate = startDate
+            }
+        }
+    }
+    
+    @Published var endDate: Date = Date() {
+        didSet {
+            if endDate < startDate {
+                startDate = endDate
+            }
+        }
+    }
     
     @Published var tagList: [Tag] = []
     @Published var selectedTag: Tag = {

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Add/ToDo/ViewModel/AddToDoViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Add/ToDo/ViewModel/AddToDoViewModel.swift
@@ -15,7 +15,7 @@ final class AddToDoViewModel: ObservableObject, TagSelectable {
     
     private var toDoService: ToDoListAPIServiceProtocol
     
-    // MARK: - User Input
+    // MARK: - Published Properties
     
     @Published var isNaturalLanguageEnabled: Bool = false {
         didSet {
@@ -37,7 +37,13 @@ final class AddToDoViewModel: ObservableObject, TagSelectable {
     @Published var endDate: Date = Date()
     
     @Published var tagList: [Tag] = []
-    @Published var selectedTag: Tag
+    @Published var selectedTag: Tag = {
+        if let untitledTag = TagManager.shared.getTag(by: "Untitled") {
+            return Tag(tagId: untitledTag.id, name: untitledTag.name, color: Color(hex: untitledTag.colorCode))
+        } else {
+            return Tag(tagId: 0, name: "Loading...", color: .gray05)
+        }
+    }()
     
     @Published var priorityUrgency: Double = 0.0
     @Published var priorityImportance: Double = 0.0
@@ -57,30 +63,13 @@ final class AddToDoViewModel: ObservableObject, TagSelectable {
     init(toDoService: ToDoListAPIServiceProtocol = ToDoListAPIService()) {
         
         self.toDoService = toDoService
-        
-        if let untitledTag = TagManager.shared.getTag(by: "Untitled") {
-            self.selectedTag = Tag(tagId: untitledTag.id, name: untitledTag.name, color: Color(hex: untitledTag.colorCode))
-        } else {
-            self.selectedTag = Tag(tagId: 0, name: "Loading...", color: .gray05)
-        }
     }
     
-    // MARK: - Computed Properties
+    // MARK: - Description & Natural Language
     
     var isTextEmpty: Bool { description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     
-    var formattedStartDate: String { formatDate(startDate) }
-    var formattedEndDate: String { formatDate(endDate) }
-    
-    var tagId: Int { selectedTag.tagId }
-    
     private var parseWorkItem: DispatchWorkItem?
-    
-    // MARK: - Date Helpers
-    
-    func formatDate(_ date: Date) -> String {
-        Calendar.current.isDateInToday(date) ? StringLiteral.AddToDo.today : date.stringFromDate(with: "MMM d")
-    }
     
     private func debouncedParse() {
         parseWorkItem?.cancel()
@@ -104,6 +93,15 @@ final class AddToDoViewModel: ObservableObject, TagSelectable {
                 self?.description = result.title
             }
         }
+    }
+    
+    // MARK: - Date Handling
+    
+    var formattedStartDate: String { formatDate(startDate) }
+    var formattedEndDate: String { formatDate(endDate) }
+    
+    func formatDate(_ date: Date) -> String {
+        Calendar.current.isDateInToday(date) ? StringLiteral.AddToDo.today : date.stringFromDate(with: "MMM d")
     }
     
     // MARK: - Priority Helpers

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditScheduleView.swift
@@ -93,20 +93,19 @@ struct EditScheduleView: View {
                         HStack {
                             Spacer()
                             
-                            Button(action: viewModel.toggleAllDay) {
+                            Button(action: {
+                                viewModel.isAllDay.toggle()
+                            }) {
                                 HStack(spacing: 10) {
                                     Image(viewModel.isAllDay ? .btn_check_selected_square : .btn_check_unselected_square)
                                         .renderingMode(.template)
-                                        .foregroundColor(viewModel.isAllDayToggleEnabled ? .gray05 : .gray07)
-                                        .opacity(viewModel.isAllDayToggleEnabled ? 1.0 : 0.5)
+                                        .foregroundColor(.gray05)
                                     
                                     Text(StringLiteral.AddSchedule.allDay)
                                         .applyFont(.body_r_14)
-                                        .foregroundColor(viewModel.isAllDayToggleEnabled ? .gray05 : .gray07)
-                                        .opacity(viewModel.isAllDayToggleEnabled ? 1.0 : 0.5)
+                                        .foregroundColor(.gray05)
                                 }
                             }
-                            .disabled(!viewModel.isAllDayToggleEnabled)
                             .padding(.trailing, 11)
                         }
                         .padding(.top, 12)
@@ -200,6 +199,8 @@ struct EditScheduleView: View {
         }
         .ignoresSafeArea(.all, edges: .bottom)
     }
+    
+    // MARK: - Date Picker
     
     private func dateTimePickerView(type: DateTimeType) -> some View {
         let title = (type == .start) ? StringLiteral.Common.starts : StringLiteral.Common.ends

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditScheduleView.swift
@@ -175,6 +175,10 @@ struct EditScheduleView: View {
                 }
                 .frame(height: calculatedSheetHeight)
                 .background(Color.gray10)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    self.hideKeyboard()
+                }
                 .gesture(
                     DragGesture()
                         .updating($translation) { value, state, _ in

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditScheduleView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditScheduleView.swift
@@ -59,6 +59,8 @@ struct EditScheduleView: View {
                         }
                         .padding(.horizontal, 18)
                         .padding(.vertical, 12)
+                        .disabled(viewModel.description.isEmpty)
+                        .opacity(viewModel.description.isEmpty ? 0.3 : 1.0)
                     }
                     .padding(.vertical, 6)
                     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditToDoView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Edit/EditToDoView.swift
@@ -59,6 +59,8 @@ struct EditToDoView: View {
                         }
                         .padding(.horizontal, 18)
                         .padding(.vertical, 12)
+                        .disabled(viewModel.description.isEmpty)
+                        .opacity(viewModel.description.isEmpty ? 0.3 : 1.0)
                     }
                     .padding(.vertical, 6)
                     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/EmptyView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/EmptyView.swift
@@ -15,6 +15,4 @@ struct EmptyView: View {
             .foregroundColor(.gray08)
             .padding(.horizontal, 48)
     }
-
 }
-

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayView.swift
@@ -21,52 +21,48 @@ struct TodayView: View {
     
     var body: some View {
         ZStack {
-            if viewModel.todayItems.isEmpty {
-                EmptyView()
-            } else {
-                ScrollView {
-                    VStack(spacing: 0) {
-                        WakeUpHeaderView(wakeUpTime: viewModel.wakeUpTime)
-                            .padding(.leading, 50)
-                            .padding(.bottom, 15)
-                        
-                        ForEach(viewModel.todayItems, id: \.id) { item in
-                            TodayListItemView(
-                                item: item,
-                                isArrow: item == viewModel.todayItems.first,
-                                isHighlighted: viewModel.isTopPriorityItem(item: item),
-                                isCompleted: viewModel.bindingForToDoCompletion(item.id)
-                            )
-                            .padding(.bottom, 10)
-                            .onTapGesture {
-                                switch item {
-                                case .todo(let todo):
-                                    selectedToDo = todo
-                                    isToDoAlertPresented = true
-                                case .schedule(let schedule):
-                                    selectedSchedule = schedule
-                                    isScheduleAlertPresented = true
-                                }
+            ScrollView {
+                VStack(spacing: 0) {
+                    WakeUpHeaderView(wakeUpTime: viewModel.wakeUpTime)
+                        .padding(.leading, 50)
+                        .padding(.bottom, 15)
+                    
+                    ForEach(viewModel.todayItems, id: \.id) { item in
+                        TodayListItemView(
+                            item: item,
+                            isArrow: item == viewModel.todayItems.first,
+                            isHighlighted: viewModel.isTopPriorityItem(item: item),
+                            isCompleted: viewModel.bindingForToDoCompletion(item.id)
+                        )
+                        .padding(.bottom, 10)
+                        .onTapGesture {
+                            switch item {
+                            case .todo(let todo):
+                                selectedToDo = todo
+                                isToDoAlertPresented = true
+                            case .schedule(let schedule):
+                                selectedSchedule = schedule
+                                isScheduleAlertPresented = true
                             }
-                            //        .onDrag {
-                            //            viewModel.dragTodayItem = currentItem
-                            //            return NSItemProvider(object: String(currentItem.id.hashValue) as NSString)
-                            //        }
-                            //        .onDrop(of: [.text], delegate: DropViewDelegate(item: item, draggedItem: $viewModel.dragTodayItem, onDrop: viewModel.dropActionForToday))
                         }
-                        
-                        WindDownFooterView(windDownTime: viewModel.windDownTime)
-                            .padding(.leading, 50)
-                            .padding(.top, 17)
+                        //        .onDrag {
+                        //            viewModel.dragTodayItem = currentItem
+                        //            return NSItemProvider(object: String(currentItem.id.hashValue) as NSString)
+                        //        }
+                        //        .onDrop(of: [.text], delegate: DropViewDelegate(item: item, draggedItem: $viewModel.dragTodayItem, onDrop: viewModel.dropActionForToday))
                     }
+                    
+                    WindDownFooterView(windDownTime: viewModel.windDownTime)
+                        .padding(.leading, 50)
+                        .padding(.top, 17)
                 }
-                .background(Color.grayBlack)
-                .onAppear {
-                    viewModel.getUserUptime()
-                }
-                .onReceive(NotificationCenter.default.publisher(for: Notification.Name("updateUptime"))) { _ in
-                    viewModel.getUserUptime()
-                }
+            }
+            .background(Color.grayBlack)
+            .onAppear {
+                viewModel.getUserUptime()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: Notification.Name("updateUptime"))) { _ in
+                viewModel.getUserUptime()
             }
         }
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayWeeklyCalendarView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayWeeklyCalendarView.swift
@@ -89,12 +89,8 @@ struct TodayWeeklyCalendarView: View {
                     updateScrollTarget()
                 }
                 .onAppear {
-                    if viewModel.isFirstFetch {
-                        viewModel.getAllEvents(useCache: false)
-                        viewModel.isFirstFetch = false
-                    } else {
-                        viewModel.getAllEvents(useCache: true)
-                    }
+                    viewModel.getAllEvents(useCache: !viewModel.isFirstFetch)
+                    viewModel.isFirstFetch = false
                     viewModel.getSchedulesAllDay()
                     updateScrollTarget()
                     viewModel.isInitialScrollDone = true

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayWeeklyCalendarView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayWeeklyCalendarView.swift
@@ -90,21 +90,21 @@ struct TodayWeeklyCalendarView: View {
                 }
                 .onAppear {
                     if viewModel.isFirstFetch {
-                        viewModel.getAllEvents(useCache: false) // 최초 → 캐시 사용 x
+                        viewModel.getAllEvents(useCache: false)
                         viewModel.isFirstFetch = false
                     } else {
-                        viewModel.getAllEvents(useCache: true) // 이후 → 캐시 허용
+                        viewModel.getAllEvents(useCache: true)
                     }
                     viewModel.getSchedulesAllDay()
                     updateScrollTarget()
                     viewModel.isInitialScrollDone = true
                 }
                 .onReceive(NotificationCenter.default.publisher(for: Notification.Name("refreshSchedule"))) { _ in
-                    viewModel.getSchedulesTotal(useCache: false) // 새로 만들면 캐시 무시
+                    viewModel.getSchedulesTotal(useCache: false)
                     viewModel.getSchedulesAllDay()
                 }
                 .onReceive(NotificationCenter.default.publisher(for: Notification.Name("refreshToDoList"))) { _ in
-                    viewModel.getToDoListTotal(useCache: false) // 새로 만들면 캐시 무시
+                    viewModel.getToDoListTotal(useCache: false)
                 }
                 .background(Color.grayBlack)
                 

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayWeeklyCalendarView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/View/Today/TodayWeeklyCalendarView.swift
@@ -207,18 +207,28 @@ struct TodayWeeklyCalendarView: View {
     
     @ViewBuilder
     private func dailyPageView(for item: MCalendarEventList) -> some View {
-        VStack(spacing: 8) {
-            AllDayListView(items: viewModel.allDayDict[viewModel.selectedDate] ?? [])
-                .padding(.vertical, 4)
+        ZStack {
+            VStack(spacing: 8) {
+                AllDayListView(items: viewModel.allDayDict[viewModel.selectedDate] ?? [])
+                    .padding(.vertical, 4)
+                
+                if !viewModel.todayItems.isEmpty {
+                    TodayView(
+                        viewModel: viewModel,
+                        isToDoAlertPresented: $isToDoAlertPresented,
+                        isScheduleAlertPresented: $isScheduleAlertPresented,
+                        selectedToDo: $selectedToDo,
+                        selectedSchedule: $selectedSchedule
+                    )
+                    .scrollContentBackground(.hidden)
+                } else {
+                    Spacer()
+                }
+            }
             
-            TodayView(
-                viewModel: viewModel,
-                isToDoAlertPresented: $isToDoAlertPresented,
-                isScheduleAlertPresented: $isScheduleAlertPresented,
-                selectedToDo: $selectedToDo,
-                selectedSchedule: $selectedSchedule
-            )
-            .scrollContentBackground(.hidden)
+            if viewModel.todayItems.isEmpty {
+                EmptyView()
+            }
         }
     }
     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditScheduleViewModel.swift
@@ -23,17 +23,24 @@ final class EditScheduleViewModel: ObservableObject {
     @Published var description: String
     
     @Published var startDate: String {
-        didSet { updateAllDayStatus() }
+        didSet { updateDateTimeAllDayState() }
     }
     
     @Published var endDate: String {
-        didSet { updateAllDayStatus() }
+        didSet { updateDateTimeAllDayState() }
     }
     
     @Published var isAllDay: Bool {
         didSet {
+            if isUpdatingAllDay { return }
+            
             if isAllDay {
-                normalizeDatesForAllDay()
+                resetDatesToStartOfDay()
+            } else {
+                isUpdatingAllDay = true
+                startDate = originalStartDate
+                endDate = originalEndDate
+                isUpdatingAllDay = false
             }
         }
     }
@@ -56,11 +63,18 @@ final class EditScheduleViewModel: ObservableObject {
         
         self.scheduleService = scheduleService
         
+        self.originalStartDate = scheduleItem.startDate
+        self.originalEndDate = scheduleItem.endDate
+        
         getTags()
-        updateAllDayStatus()
     }
     
     // MARK: - All-Day Handling
+    
+    private let originalStartDate: String
+    private let originalEndDate: String
+    
+    private var isUpdatingAllDay = false
     
     private var startDateTime: Date {
         Date.dateFromString(startDate, format: "yyyy-MM-dd'T'HH:mm:ss.SSS")
@@ -74,36 +88,19 @@ final class EditScheduleViewModel: ObservableObject {
         ?? Date()
     }
     
-    private var dayDifference: Int {
-        Calendar.current.dateComponents([.day],
-                                        from: Calendar.current.startOfDay(for: startDateTime),
-                                        to: Calendar.current.startOfDay(for: endDateTime)
-        ).day ?? 0
-    }
-    
-    var isAllDayToggleEnabled: Bool {
-        dayDifference < 2
-    }
-    
-    private func updateAllDayStatus() {
-        let shouldBeAllDay = isOverOneDay()
-        if shouldBeAllDay != isAllDay {
-            isAllDay = shouldBeAllDay
-        }
-    }
-    
-    private func normalizeDatesForAllDay() {
+    private func resetDatesToStartOfDay() {
         startDate = startDateTime.startOfDay.stringFromDate(with: "yyyy-MM-dd'T'HH:mm:ss")
         endDate = endDateTime.startOfDay.stringFromDate(with: "yyyy-MM-dd'T'HH:mm:ss")
     }
     
-    func toggleAllDay() {
-        guard isAllDayToggleEnabled else { return }
-        isAllDay.toggle()
-    }
-    
-    func isOverOneDay() -> Bool {
-        endDateTime.timeIntervalSince(startDateTime) >= TimeInterval.oneDay
+    private func updateDateTimeAllDayState() {
+        if isUpdatingAllDay { return }
+        
+        let interval = endDateTime.timeIntervalSince(startDateTime)
+        
+        if interval >= .oneDay && !isAllDay {
+            isAllDay = true
+        }
     }
     
     // MARK: - API
@@ -125,7 +122,7 @@ final class EditScheduleViewModel: ObservableObject {
     }
     
     func updateSchedule(completion: @escaping () -> Void) {
-        let tagId = tagList.first(where: { $0.name == tagName })?.tagId ?? tagList.first?.tagId ?? 1
+        let tagId = tagList.first(where: { $0.name == tagName })?.tagId ?? tagList.first?.tagId ?? 0
         
         let body = SchedulePostRequest(
             description: description,

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditScheduleViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditScheduleViewModel.swift
@@ -18,7 +18,7 @@ final class EditScheduleViewModel: ObservableObject {
     
     private let scheduleId: Int
     
-    // MARK: - User Input
+    // MARK: - Published Properties
     
     @Published var description: String
     
@@ -97,6 +97,13 @@ final class EditScheduleViewModel: ObservableObject {
         if isUpdatingAllDay { return }
         
         let interval = endDateTime.timeIntervalSince(startDateTime)
+        
+        if endDateTime <= startDateTime {
+            isUpdatingAllDay = true
+            let newEnd = startDateTime.addingTimeInterval(.twoHours)
+            endDate = newEnd.stringFromDate(with: "yyyy-MM-dd'T'HH:mm:ss")
+            isUpdatingAllDay = false
+        }
         
         if interval >= .oneDay && !isAllDay {
             isAllDay = true

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditToDoViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditToDoViewModel.swift
@@ -18,7 +18,7 @@ final class EditToDoViewModel: ObservableObject {
     
     private let toDoId: Int
     
-    // MARK: - User Input
+    // MARK: - Published Properties
     
     @Published var description: String
     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditToDoViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditToDoViewModel.swift
@@ -74,8 +74,8 @@ final class EditToDoViewModel: ObservableObject {
             description: description,
             endDate: endDate,
             tagId: tagId,
-            priorityUrgency: priorityType.getPriorityValues().urgency,
-            priorityImportance: priorityType.getPriorityValues().importance
+            priorityUrgency: priorityType == .none ? nil : priorityType.getPriorityValues().urgency,
+            priorityImportance: priorityType == .none ? nil : priorityType.getPriorityValues().importance
         )
         
         toDoService.updateToDo(toDoId: toDoId, body: body) { _ in

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditToDoViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/EditToDoViewModel.swift
@@ -22,8 +22,13 @@ final class EditToDoViewModel: ObservableObject {
     
     @Published var description: String
     
-    @Published var startDate: String
-    @Published var endDate: String
+    @Published var startDate: String {
+        didSet { validateDates(updatedBy: .start) }
+    }
+    
+    @Published var endDate: String {
+        didSet { validateDates(updatedBy: .end) }
+    }
     
     @Published var tagName: String
     @Published var tagColor: String
@@ -46,6 +51,22 @@ final class EditToDoViewModel: ObservableObject {
         self.toDoService = toDoService
         
         getTags()
+    }
+    
+    // MARK: - Date Handling
+    
+    private func validateDates(updatedBy type: DateTimeType) {
+        guard let start = Date.dateFromString(startDate, format: "yyyy-MM-dd"),
+              let end = Date.dateFromString(endDate, format: "yyyy-MM-dd") else { return }
+        
+        if start > end {
+            switch type {
+            case .start:
+                endDate = start.stringFromDate(with: "yyyy-MM-dd")
+            case .end:
+                startDate = end.stringFromDate(with: "yyyy-MM-dd")
+            }
+        }
     }
     
     // MARK: - API

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/WeeklyCalendarViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/WeeklyCalendarViewModel.swift
@@ -179,9 +179,14 @@ extension WeeklyCalendarViewModel {
         allDayDict.removeAll()
         
         for dateModel in mCallendarDataSource.wholeMonthDate {
+            guard let currentDate = dateModel.date() else { continue }
+            let dayStart = currentDate.startOfDay
+            let dayEnd = currentDate.endOfDay
+            
             allDayDict[dateModel] = allDayItems.filter { allDayItem in
-                guard let itemDate = dateFromScheduleString(allDayItem.startDate) else { return false }
-                return itemDate.startOfDay == dateModel.date()?.startOfDay
+                guard let start = dateFromScheduleString(allDayItem.startDate),
+                      let end = dateFromScheduleString(allDayItem.endDate) else { return false }
+                return start <= dayEnd && end >= dayStart
             }
         }
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/WeeklyCalendarViewModel.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Main/ViewModel/WeeklyCalendarViewModel.swift
@@ -31,7 +31,7 @@ final class WeeklyCalendarViewModel: ObservableObject {
     @Published var allDayDict: [MCalendarDataModel: [AllDayItem]] = [:]
     @Published var toDoItems: [ToDoItem] = []
     @Published var toDoListDict: [MCalendarDataModel: [ToDoItem]] = [:]
-
+    
     @Published var wakeUpTime: String = "8 AM"
     @Published var windDownTime: String = "11 PM"
     
@@ -243,6 +243,8 @@ extension WeeklyCalendarViewModel {
            let index = self.toDoListDict[date]?.firstIndex(where: { $0.id == toDoId }) {
             self.toDoListDict[date]?[index].isCompleted.toggle()
         }
+        
+        ToDoCache.shared.set(key: "todos", data: self.toDoItems)
     }
 }
 
@@ -271,11 +273,10 @@ extension WeeklyCalendarViewModel {
         }
     }
     
-    // Schedule 불러오기
     func getSchedulesTotal(useCache: Bool = true) {
         let start = Date()
         
-        // 1. 최초 실행이면 캐시 무시
+        // 최초 실행이면 캐시 무시
         if !isFirstFetch, useCache, let cached = ScheduleCache.shared.get(key: "schedules") {
             DispatchQueue.main.async {
                 self.scheduleItems = cached
@@ -284,11 +285,13 @@ extension WeeklyCalendarViewModel {
                     self.updateTodayItems(for: date)
                 }
             }
+            
             APICacheLogger.shared.logCacheCall(start: start, apiName: "Schedule")
+            
             return
         }
         
-        // 2. 서버 호출
+        // 서버 호출
         scheduleService.getSchedulesTotal { [weak self] result in
             guard let self else { return }
             
@@ -299,13 +302,14 @@ extension WeeklyCalendarViewModel {
                 DispatchQueue.main.async {
                     self.scheduleItems = mapped
                     self.getAllScheduleList = true
-                    ScheduleCache.shared.set(key: "schedules", data: mapped) // ✅ 캐시에 저장
-                    self.isFirstFetch = false // 최초 실행 완료
+                    ScheduleCache.shared.set(key: "schedules", data: mapped)
+                    self.isFirstFetch = false
                     if let date = self.selectedDate.date() {
                         self.updateTodayItems(for: date)
                     }
                 }
             }
+            
             APICacheLogger.shared.logServerCall(start: start, apiName: "Schedule")
         }
     }
@@ -330,7 +334,7 @@ extension WeeklyCalendarViewModel {
     func getToDoListTotal(useCache: Bool = true) {
         let start = Date()
         
-        // 1. 최초 실행이면 캐시 무시
+        // 최초 실행이면 캐시 무시
         if !isFirstFetch, useCache, let cached = ToDoCache.shared.get(key: "todos") {
             DispatchQueue.main.async {
                 self.toDoItems = cached
@@ -340,11 +344,13 @@ extension WeeklyCalendarViewModel {
                     self.updateTodayItems(for: date)
                 }
             }
+            
             APICacheLogger.shared.logCacheCall(start: start, apiName: "ToDo")
+            
             return
         }
         
-        // 2. 서버 호출
+        // 서버 호출
         toDoService.getToDoListTotal { [weak self] result in
             guard let self else { return }
             
@@ -356,17 +362,17 @@ extension WeeklyCalendarViewModel {
                     self.toDoItems = mapped
                     self.mapToDoDictByDate()
                     self.getAllToDoList = true
-                    ToDoCache.shared.set(key: "todos", data: mapped) // 캐시에 저장
-                    self.isFirstFetch = false // 최초 실행 완료
+                    ToDoCache.shared.set(key: "todos", data: mapped)
+                    self.isFirstFetch = false
                     if let date = self.selectedDate.date() {
                         self.updateTodayItems(for: date)
                     }
                 }
             }
+            
             APICacheLogger.shared.logServerCall(start: start, apiName: "ToDo")
         }
     }
-    
     
     func updateToDoCompletion(toDoId: Int) {
         toDoService.updateToDoCompletion(toDoId: toDoId) { [weak self] result in


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
스크린샷 참고


## 🚨 참고 사항
다음 작업에서 WeeklyCalendarViewModel 개선하면서
1. 스케줄, 투두 업데이트하는 로직
2. Notification 없이 생성 후 UI 반영하는 로직
3. 투두 체크 시 UI 변동 (밑으로 이동)
건드려보겠습니다

4. MHorizontalCalendar가 mCallendarDatasource 쪽에서 날짜를 결정하는 것 같은데 그래서 자꾸 2023년 11월 쯤으로 초기화되는 문제가 빈번하게 발생 중이라 이것도 볼게요


## 📸 스크린샷
  |   올데이 + 일정   |   올데이만   |   일정만   | X |
 | :----------: | :----------: | :----------: | :----------: |
 | <img src = "https://github.com/user-attachments/assets/6f2446be-ab53-4355-b823-01b29aea0ece" width ="220"> | <img src = "https://github.com/user-attachments/assets/8aabcc13-1a07-4c90-af55-018fa9adc92e" width ="220"> | <img src = "https://github.com/user-attachments/assets/975ec4cd-137e-4317-a7da-0721adcd7b5e" width ="220"> | <img src = "https://github.com/user-attachments/assets/fa5b306b-b121-4712-91c1-c534db4f1eb8" width ="220"> |

<br>

 |   before   |   after <br> (ScheduleType(Notion, Apple 등) 이 현재 없어서 빈 공간 없앰)   |  
 | :----------: | :----------: |
 | <img src = "https://github.com/user-attachments/assets/493357bb-bf81-4716-a868-b1947b8c82f5" width ="230"> | <img src = "https://github.com/user-attachments/assets/f37ebe79-006a-46ed-a2f3-f7369edc789c" width ="230"> |

<br>

|   투두 동기화   |   올데이 해당 날짜에 모두 표시 <br> 버퍼링 ㄷㄷ ㅋㅋ  | 
 | :----------: | :----------: | 
 | <video src = "https://github.com/user-attachments/assets/c046eef8-37e2-4663-a427-ed216797e9f3" width ="230"> | <video src = "https://github.com/user-attachments/assets/6734fcb0-7a1f-4e9e-8c66-aa37cfe6146b" width ="230"> | 

<br>

 |   편집 시 텍스트 없으면 Done 비활성화 <br> 스케줄   |  편집 시 텍스트 없으면 Done 비활성화 <br> 투두   |
| :----------: | :----------: | 
| <video src = "https://github.com/user-attachments/assets/c42736b7-853b-4b32-9542-c4c4f55c6ed0" width ="230"> | <video src = "https://github.com/user-attachments/assets/eaddfcfe-f56a-499b-b965-94b65124b442" width ="230"> |

<br>

|  올데이 했다가 다시 해제하면 디폴트로   |   피그마 참고  | 
 | :----------: | :----------: | 
 | <video src = "https://github.com/user-attachments/assets/b94c65b5-5d32-4c0f-8d55-38facb10fce1" width ="230"> | <img src = "https://github.com/user-attachments/assets/8b3937f2-a9df-41ce-985b-4d2237ec20fb" width ="330"> <br> <img src = "https://github.com/user-attachments/assets/975ec45a-d695-45c6-8bcf-d5b435a3fcf9" width ="330"> | 



 | start가 end보다 이후일 때 <br> end를 start + 2시간으로 자동 업데이트   |   스케줄 생성 텍스트 입력 시 <br> 다른 영역 터치하면 키보드 내려가기 <br> (스크린샷에 안보이겠지만 다른 영역 누르고 있음 ;;)   |
| :----------: | :----------: | 
 | <video src = "https://github.com/user-attachments/assets/564a5a4c-d3a8-4072-aaf5-22b2ea0fa177" width ="230"> | <video src = "https://github.com/user-attachments/assets/02b3a02e-596f-4398-b94b-9e85c6674291" width ="230"> |




## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #64 
