### PR TITLE
[Chore] #70 - Tag 관련 수정 및 Alert 추가

### DIFF
--- a/Memento-iOS/Memento-iOS/Source/Component/Alert/CustomAlertView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Component/Alert/CustomAlertView.swift
@@ -29,6 +29,8 @@ struct CustomAlertView: View {
                     .applyFont(.body_b_14)
                     .foregroundColor(Color.gray07)
                     .multilineTextAlignment(.center)
+            } else {
+                Spacer().frame(height: 2)
             }
             
             HStack(spacing: 8) {

--- a/Memento-iOS/Memento-iOS/Source/Component/Alert/SingleButtonAlertView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Component/Alert/SingleButtonAlertView.swift
@@ -1,0 +1,36 @@
+//
+//  SingleButtonAlertView.swift
+//  Memento-iOS
+//
+//  Created by 이세민 on 11/11/25.
+//
+
+import SwiftUI
+import MDSKit
+
+struct SingleButtonAlertView: View {
+    let title: String
+    let buttonTitle: String
+    let buttonAction: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 29) {
+            Text(title)
+                .applyFont(.body_r_14)
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+            
+            Button(action: buttonAction) {
+                Text(buttonTitle)
+                    .applyFont(.body_r_14)
+                    .foregroundColor(Color.gray03)
+                    .frame(maxWidth: 137, minHeight: 36)
+                    .background(Color.gray08)
+                    .cornerRadius(4)
+            }
+        }
+        .padding(EdgeInsets(top: 28, leading: 70, bottom: 14, trailing: 70))
+        .background(Color.gray09)
+        .cornerRadius(4)
+    }
+}

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/Model/TagItem.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/Model/TagItem.swift
@@ -11,5 +11,6 @@ struct TagItem: Identifiable, Hashable {
     let id = UUID()
     var title: String
     var color: Color
+    var colorHex: String
     var isChevronVisible: Bool
 }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/SettingView.swift
@@ -83,7 +83,7 @@ struct SettingView: View {
                     
                     if showLogoutAlert {
                         CustomAlertView(
-                            title: "Do you really want to logout?",
+                            title: "Would you like to Logout?",
                             message: nil,
                             cancelTitle: "Cancel",
                             confirmTitle: "Logout",

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
@@ -15,6 +15,7 @@ struct TagEditDetailView: View {
     @State var tag: TagItem
     @State private var originalTagId: Int?
     @State private var showDeleteAlert = false
+    @State private var showDuplicateAlert = false
     @State private var alertMessage = ""
     
     let tagColors = [Color.mementoRed, Color.mementoPink, Color.mementoOrange, Color.mementoYellow, Color.mementoLightGreen, Color.mementoMint, Color.mementoCyan, Color.mementoBlue, Color.mementoPurple, Color.gray05]
@@ -128,6 +129,7 @@ struct TagEditDetailView: View {
             Spacer()
         }
         .overlay(deleteAlertView)
+        .overlay(duplicateAlertView)
     }
     
     @ViewBuilder
@@ -146,8 +148,33 @@ struct TagEditDetailView: View {
         }
     }
     
+    @ViewBuilder
+    private var duplicateAlertView: some View {
+        if showDuplicateAlert {
+            SingleButtonAlertView(
+                title: "Tag name already exists.",
+                buttonTitle: "OK",
+                buttonAction: { showDuplicateAlert = false }
+            )
+            .padding(.horizontal, 32)
+            .preferredColorScheme(.dark)
+        }
+    }
+    
     private func saveOrUpdateTag() {
         guard !tag.title.isEmpty else { return }
+        
+        let savedTags = TagManager.shared.getSavedTags()
+        
+        let isDuplicate = savedTags.contains { savedTag in
+            savedTag.name == tag.title &&
+            (!isNew ? savedTag.id != originalTagId : true)
+        }
+        
+        if isDuplicate {
+            showDuplicateAlert = true
+            return
+        }
         
         let request = TagPostRequest(name: tag.title, hexCode: tag.colorHex)
         

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
@@ -14,7 +14,6 @@ struct TagEditDetailView: View {
     
     @State var tag: TagItem
     @State private var originalTagId: Int?
-    @State private var showAlert = false
     @State private var showDeleteAlert = false
     @State private var alertMessage = ""
     
@@ -108,11 +107,6 @@ struct TagEditDetailView: View {
                 Spacer()
         }
         .overlay(deleteAlertView)
-        .alert("Alert", isPresented: $showAlert) {
-            Button("OK") {
-                if alertMessage.contains("success") { viewModel.navigateBack() }
-            }
-        } message: { Text(alertMessage) }
     }
     
     @ViewBuilder
@@ -146,8 +140,6 @@ struct TagEditDetailView: View {
                 } else {
                     DispatchQueue.main.async {
                         print("태그 생성 실패")
-                        alertMessage = "Failed to create tag."
-                        showAlert = true
                     }
                 }
             }
@@ -163,7 +155,6 @@ struct TagEditDetailView: View {
                         print("태그 수정 실패")
                         alertMessage = "Failed to update tag."
                     }
-                    showAlert = true
                 }
             }
         }
@@ -176,12 +167,9 @@ struct TagEditDetailView: View {
                 if success {
                     print("태그 삭제 성공")
                     viewModel.navigateBack()
-                    alertMessage = "Tag deleted successfully."
                 } else {
                     print("태그 삭제 실패")
-                    alertMessage = "Failed to delete tag."
                 }
-                showAlert = true
             }
         }
     }

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
@@ -190,6 +190,7 @@ struct TagEditDetailView: View {
         }
     }
     
+    // 태그 생성 및 수정 중 변경 사항 있는지 판단
     private func hasUnsavedChanges() -> Bool {
         if isNew {
             return !tag.title.isEmpty || tag.colorHex != "#A9ADBB"
@@ -200,6 +201,7 @@ struct TagEditDetailView: View {
         }
     }
     
+    // 태그 생성 및 수정 (중복 이름 검사 + isNew로 분기 처리)
     private func saveOrUpdateTag() {
         guard !tag.title.isEmpty else { return }
         
@@ -247,6 +249,7 @@ struct TagEditDetailView: View {
         }
     }
     
+    // 태그 삭제
     private func deleteTag() {
         guard let tagId = originalTagId else { return }
         TagManager.shared.deleteTag(tagId: tagId) { success in

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
@@ -16,6 +16,7 @@ struct TagEditDetailView: View {
     @State private var originalTagId: Int?
     @State private var showDeleteAlert = false
     @State private var showDuplicateAlert = false
+    @State private var showUnsavedChangesAlert = false
     @State private var alertMessage = ""
     
     let tagColors = [Color.mementoRed, Color.mementoPink, Color.mementoOrange, Color.mementoYellow, Color.mementoLightGreen, Color.mementoMint, Color.mementoCyan, Color.mementoBlue, Color.mementoPurple, Color.gray05]
@@ -52,7 +53,13 @@ struct TagEditDetailView: View {
             showBackButton: true,
             showSkipButton: true,
             skipButtonTitle: "Done",
-            backButtonAction: { viewModel.navigateBack() },
+            backButtonAction: {
+                if hasUnsavedChanges() {
+                    showUnsavedChangesAlert = true
+                } else {
+                    viewModel.navigateBack()
+                }
+            },
             skipButtonAction: { saveOrUpdateTag() }
         )
         
@@ -130,6 +137,7 @@ struct TagEditDetailView: View {
         }
         .overlay(deleteAlertView)
         .overlay(duplicateAlertView)
+        .overlay(unsavedChangesAlertView)
     }
     
     @ViewBuilder
@@ -158,6 +166,37 @@ struct TagEditDetailView: View {
             )
             .padding(.horizontal, 32)
             .preferredColorScheme(.dark)
+        }
+    }
+    
+    @ViewBuilder
+    private var unsavedChangesAlertView: some View {
+        if showUnsavedChangesAlert {
+            CustomAlertView(
+                title: "Are you sure you want to discard \nthese changes?",
+                message: nil,
+                cancelTitle: "Keep Editing",
+                confirmTitle: "Discard Changes",
+                confirmAction: {
+                    showUnsavedChangesAlert = false
+                    viewModel.navigateBack()
+                },
+                cancelAction: {
+                    showUnsavedChangesAlert = false
+                }
+            )
+            .padding(.horizontal, 32)
+            .preferredColorScheme(.dark)
+        }
+    }
+    
+    private func hasUnsavedChanges() -> Bool {
+        if isNew {
+            return !tag.title.isEmpty || tag.colorHex != "#A9ADBB"
+        } else {
+            guard let originalId = originalTagId,
+                  let savedTag = TagManager.shared.getSavedTags().first(where: { $0.id == originalId }) else { return false }
+            return savedTag.name != tag.title || savedTag.colorCode != tag.colorHex
         }
     }
     

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditDetailView.swift
@@ -21,13 +21,28 @@ struct TagEditDetailView: View {
     var isNew: Bool = false
     
     init(tag: TagItem?, isNew: Bool) {
-        self._tag = State(initialValue: tag ?? TagItem(title: "", color: .gray05, isChevronVisible: false))
-        self.isNew = isNew
+        var initialTag = TagItem(
+            title: "",
+            color: .gray05,
+            colorHex: "#A9ADBB",
+            isChevronVisible: false
+        )
         
         if let tagItem = tag, !isNew {
             let savedTags = TagManager.shared.getSavedTags()
-            self._originalTagId = State(initialValue: savedTags.first(where: { $0.name == tagItem.title })?.id)
+            if let savedTag = savedTags.first(where: { $0.name == tagItem.title }) {
+                initialTag = TagItem(
+                    title: tagItem.title,
+                    color: Color.fromHex(savedTag.colorCode),
+                    colorHex: savedTag.colorCode,
+                    isChevronVisible: false
+                )
+                self._originalTagId = State(initialValue: savedTag.id)
+            }
         }
+        
+        self._tag = State(initialValue: initialTag)
+        self.isNew = isNew
     }
     
     var body: some View {
@@ -40,71 +55,77 @@ struct TagEditDetailView: View {
             skipButtonAction: { saveOrUpdateTag() }
         )
         
+        VStack(alignment: .leading) {
             VStack(alignment: .leading) {
-                VStack(alignment: .leading) {
-                    Text(SettingsTagViewText.tagName)
-                        .applyFont(.detail_r_12)
-                        .foregroundColor(.gray06)
-                        .padding(.top, 12)
-                        .padding(.horizontal, 16)
-                    
-                    ZStack(alignment: .leading) {
-                        if tag.title.isEmpty {
-                            Text(SettingsTagViewText.enterTagName)
-                                .foregroundColor(.gray07)
-                                .applyFont(.body_r_14)
-                        }
-                        TextField("", text: $tag.title)
-                            .tint(Color.mementoLightGreen)
-                            .foregroundColor(.gray03)
-                            .applyFont(.body_r_14)
-                            .autocorrectionDisabled(true)
-                    }
-                    .padding(.top, 9)
+                Text(SettingsTagViewText.tagName)
+                    .applyFont(.detail_r_12)
+                    .foregroundColor(.gray06)
+                    .padding(.top, 12)
                     .padding(.horizontal, 16)
-                    .frame(height: 20)
-
-                    Divider()
-                        .frame(height: 1)
-                        .background(Color.gray05)
-                        .padding(.horizontal, 12)
-                    
-                    Text(SettingsTagViewText.color)
-                        .applyFont(.detail_r_12)
-                        .foregroundColor(.gray06)
-                        .padding(.top, 30)
-                        .padding(.horizontal, 16)
-                    
-                    HStack(spacing: 13) {
-                        ForEach(tagColors, id: \.self) { color in
-                            Circle()
-                                .fill(color)
-                                .frame(width: 18, height: 18)
-                                .overlay(
-                                    Circle().strokeBorder(Color.white, lineWidth: tag.color == color ? 2 : 0)
-                                )
-                                .onTapGesture { tag.color = color }
-                        }
-                    }
-                    .padding(.top, 14)
-                    .padding(.bottom, 24)
-                    .padding(.horizontal, 19)
-                }
-                .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray10))
-                .padding(.top, 26)
-                .padding(.horizontal, 20)
                 
-                if !isNew {
-                    Button { showDeleteAlert = true } label: {
-                        Text(SettingsTagViewText.deleteTag)
+                ZStack(alignment: .leading) {
+                    if tag.title.isEmpty {
+                        Text(SettingsTagViewText.enterTagName)
+                            .foregroundColor(.gray07)
                             .applyFont(.body_r_14)
-                            .foregroundColor(Color.mementoRed)
                     }
-                    .padding(.top, 20)
-                    .padding(.leading, 31)
+                    TextField("", text: $tag.title)
+                        .tint(Color.mementoLightGreen)
+                        .foregroundColor(.gray03)
+                        .applyFont(.body_r_14)
+                        .autocorrectionDisabled(true)
                 }
+                .padding(.top, 9)
+                .padding(.horizontal, 16)
+                .frame(height: 20)
                 
-                Spacer()
+                Divider()
+                    .frame(height: 1)
+                    .background(Color.gray05)
+                    .padding(.horizontal, 12)
+                
+                Text(SettingsTagViewText.color)
+                    .applyFont(.detail_r_12)
+                    .foregroundColor(.gray06)
+                    .padding(.top, 30)
+                    .padding(.horizontal, 16)
+                
+                HStack(spacing: 13) {
+                    ForEach(tagColors, id: \.self) { color in
+                        Circle()
+                            .fill(color)
+                            .frame(width: 18, height: 18)
+                            .overlay(
+                                Circle().strokeBorder(
+                                    Color.white,
+                                    lineWidth: tag.colorHex == colorToHex(color) ? 2 : 0
+                                )
+                            )
+                            .onTapGesture {
+                                tag.color = color
+                                tag.colorHex = colorToHex(color)
+                            }
+                    }
+                }
+                .padding(.top, 14)
+                .padding(.bottom, 24)
+                .padding(.horizontal, 19)
+            }
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray10))
+            .padding(.top, 26)
+            .padding(.horizontal, 20)
+            
+            if !isNew {
+                Button { showDeleteAlert = true } label: {
+                    Text(SettingsTagViewText.deleteTag)
+                        .applyFont(.body_r_14)
+                        .foregroundColor(Color.mementoRed)
+                }
+                .padding(.top, 20)
+                .padding(.leading, 31)
+            }
+            
+            Spacer()
         }
         .overlay(deleteAlertView)
     }
@@ -128,7 +149,7 @@ struct TagEditDetailView: View {
     private func saveOrUpdateTag() {
         guard !tag.title.isEmpty else { return }
         
-        let request = TagPostRequest(name: tag.title, hexCode: colorToHex(tag.color))
+        let request = TagPostRequest(name: tag.title, hexCode: tag.colorHex)
         
         if isNew {
             TagManager.shared.createAndSaveTag(request: request) { response in

--- a/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditView.swift
+++ b/Memento-iOS/Memento-iOS/Source/Presentation/Setting/View/TagEditView.swift
@@ -30,6 +30,7 @@ struct TagEditView: View {
                     item: TagItem(
                         title: "Untitled",
                         color: Color.fromHex("#A9ADBB"),
+                        colorHex: "#A9ADBB",
                         isChevronVisible: false
                     )
                 )
@@ -39,6 +40,7 @@ struct TagEditView: View {
                     let tagItem = TagItem(
                         title: tag.name,
                         color: Color.fromHex(tag.colorCode),
+                        colorHex: tag.colorCode,
                         isChevronVisible: true
                     )
                     


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 태그 수정/삭제 시 표시되었던 기본 Alert 삭제
- 기존 태그 선택 시 태그의 색상이 하얀색 테두리 선으로 적용된 표시가 되어있지 않던 문제 수정
- 중복 이름 생성 시 Custom Alert 표시
- 태그 생성/수정 중 변경사항 있는 상태로 뒤로가기 시 Custom Alert 표시 (다시 변경사항 없는 상태로 만들면 뒤로가기 수행)

## 📸 스크린샷
|   before <br> 기존 태그 선택 시 해당 태그의 색상이 적용되어있지 않음 (하얀색 테두리 표시 x), <br> 그대로 Done 누르면 기본 색상 (gray05) 으로 수정됨   |   after  | 
 | :----------: | :----------: | 
 | <video src = "https://github.com/user-attachments/assets/39a2b959-1308-4e64-a5ae-3a41b9ac2510" width ="230"> | <video src = "https://github.com/user-attachments/assets/b6bb82a6-f18e-4224-9a58-d0dddb7ab0b7" width ="230"> | 

<br>

  |   이미 있는 sem으로 수정하려고 할 때 중복되었다는 Alert 표시   |   수정 시 변경사항 있는 상태로 뒤로가기 눌렀을 때 Alert 표시   |   생성 시 변경사항 있는 상태로 뒤로가기 눌렀을 때 Alert 표시   |
 | :----------: | :----------: | :----------: |
 | <video src = "https://github.com/user-attachments/assets/15d27060-02df-4c26-9334-2e25afa7b98f" width ="220"> | <video src = "https://github.com/user-attachments/assets/41b0e623-dbb9-4c8f-8b03-a6830305e37a" width ="220"> | <video src = "https://github.com/user-attachments/assets/837d855d-6583-4d33-8f1e-f867c558d6b4" width ="220"> |


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #70 
